### PR TITLE
Improvement: fix missing arguments and add new flag for monthly run

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "views_pipeline_core"
-version = "2.1.1"
+version = "2.1.2"
 description = ""
 authors = [
     "Borbála Farkas <borbala.farkas@pcr.uu.se>",

--- a/views_pipeline_core/cli/utils.py
+++ b/views_pipeline_core/cli/utils.py
@@ -115,15 +115,35 @@ def parse_args():
         help="Enable Weights & Biases notifications.",
     )
 
+    parser.add_argument(
+        "-m",
+        "--monthly",
+        action="store_true",
+        help="Shorthand flag for monthly production runs. "
+        "Automatically sets: --run_type forecasting, --train, --forecast, --report, --prediction_store, --wandb_notifications.",
+    )
+
     return parser.parse_args()
 
 
 def validate_arguments(args):
-    # if args.report and not args.forecast and not args.evaluate:
-    #     print(
-    #         "Error: --report flag requires either --forecast or --evaluate to be set. Exiting."
-    #     )
-    #     sys.exit(1)
+    if args.monthly:
+        if args.sweep:
+            print("Error: --monthly flag cannot be used with --sweep flag. Exiting.")
+            print("To fix: Remove --sweep flag when using --monthly.")
+            sys.exit(1)
+        
+        if args.evaluate:
+            print("Error: --monthly flag cannot be used with --evaluate flag (monthly runs do forecasting, not evaluation). Exiting.")
+            print("To fix: Remove --evaluate flag when using --monthly.")
+            sys.exit(1)
+        
+        args.run_type = "forecasting"
+        args.train = True
+        args.forecast = True
+        args.report = True
+        args.prediction_store = True
+        args.wandb_notifications = True
 
     if args.report and args.run_type not in ("forecasting", "validation"):
         print("Error: --report can only be used with --run_type forecasting or validation. Exiting.")

--- a/views_pipeline_core/managers/ensemble.py
+++ b/views_pipeline_core/managers/ensemble.py
@@ -908,7 +908,6 @@ class EnsembleManager(ForecastingModelManager):
                         evaluate=True,
                         eval_type=eval_type,
                         update_viewser=update_viewser,
-                        prediction_store=self._use_prediction_store,
                         wandb_notifications=self._wandb_notifications,
                     )
                     pred = pd.DataFrame.forecasts.read_store(
@@ -933,7 +932,6 @@ class EnsembleManager(ForecastingModelManager):
                         evaluate=True,
                         eval_type=eval_type,
                         update_viewser=update_viewser,
-                        prediction_store=self._use_prediction_store,
                         wandb_notifications=self._wandb_notifications,
                     )
                     pred = read_dataframe(

--- a/views_pipeline_core/managers/ensemble.py
+++ b/views_pipeline_core/managers/ensemble.py
@@ -851,7 +851,6 @@ class EnsembleManager(ForecastingModelManager):
             train=True,
             use_saved=use_saved,
             update_viewser=update_viewser,
-            prediction_store=self._use_prediction_store,
             wandb_notifications=self._wandb_notifications,
         )
 

--- a/views_pipeline_core/managers/ensemble.py
+++ b/views_pipeline_core/managers/ensemble.py
@@ -773,6 +773,8 @@ class EnsembleManager(ForecastingModelManager):
         use_saved: bool = True,
         eval_type: str = "standard",
         update_viewser: bool = False,
+        prediction_store: bool = False,
+        wandb_notifications: bool = False,
     ) -> None:
         """
         Executes a shell script for a model artifact.
@@ -787,6 +789,8 @@ class EnsembleManager(ForecastingModelManager):
             use_saved (bool, optional): Whether to use saved data. Defaults to True.
             eval_type (str, optional): The type of evaluation to perform. Defaults to "standard".
             update_viewser (bool, optional): Whether to update the viewser dataframe. Defaults to False.
+            prediction_store (bool, optional): Whether to use the prediction store. Defaults to False.
+            wandb_notifications (bool, optional): Whether to send notifications to Weights & Biases. Defaults to False.
 
         Raises:
             Exception: If an error occurs during the execution of the shell command.
@@ -805,6 +809,8 @@ class EnsembleManager(ForecastingModelManager):
             use_saved=use_saved,
             eval_type=eval_type,
             update_viewser=update_viewser,
+            prediction_store=prediction_store,
+            wandb_notifications=wandb_notifications,
         )
 
         try:
@@ -845,6 +851,8 @@ class EnsembleManager(ForecastingModelManager):
             train=True,
             use_saved=use_saved,
             update_viewser=update_viewser,
+            prediction_store=self._use_prediction_store,
+            wandb_notifications=self._wandb_notifications,
         )
 
     def _evaluate_model_artifact(
@@ -901,6 +909,8 @@ class EnsembleManager(ForecastingModelManager):
                         evaluate=True,
                         eval_type=eval_type,
                         update_viewser=update_viewser,
+                        prediction_store=self._use_prediction_store,
+                        wandb_notifications=self._wandb_notifications,
                     )
                     pred = pd.DataFrame.forecasts.read_store(
                         run=self._pred_store_name, name=name
@@ -924,6 +934,8 @@ class EnsembleManager(ForecastingModelManager):
                         evaluate=True,
                         eval_type=eval_type,
                         update_viewser=update_viewser,
+                        prediction_store=self._use_prediction_store,
+                        wandb_notifications=self._wandb_notifications,
                     )
                     pred = read_dataframe(
                         f"{path_generated}/predictions_{run_type}_{ts}_{str(sequence_number).zfill(2)}{PipelineConfig().dataframe_format}"
@@ -980,6 +992,8 @@ class EnsembleManager(ForecastingModelManager):
                     model_name,
                     forecast=True,
                     update_viewser=update_viewser,
+                    prediction_store=self._use_prediction_store,
+                    wandb_notifications=self._wandb_notifications,
                 )
                 pred = pd.DataFrame.forecasts.read_store(
                     run=self._pred_store_name, name=name
@@ -1002,6 +1016,8 @@ class EnsembleManager(ForecastingModelManager):
                     model_name,
                     forecast=True,
                     update_viewser=update_viewser,
+                    prediction_store=self._use_prediction_store,
+                    wandb_notifications=self._wandb_notifications,
                 )
                 pred = read_dataframe(
                     f"{path_generated}/predictions_{run_type}_{ts}{PipelineConfig().dataframe_format}"


### PR DESCRIPTION
- Fix missing arguments in ensemble forecasting by adding `prediction_store` and `wandb_notifications` parameters
- Add new flag `--monthly (or -m)` to automate a monthly run for forecasting