### PR TITLE
Feature/override timestep

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "views_pipeline_core"
-version = "2.1.2"
+version = "2.1.3"
 description = ""
 authors = [
     "Borbála Farkas <borbala.farkas@pcr.uu.se>",

--- a/tests/test_ensemble_manager.py
+++ b/tests/test_ensemble_manager.py
@@ -17,7 +17,7 @@ from pathlib import Path
 
 
 class MockArgs:
-    def __init__(self, train, evaluate, forecast, saved, run_type, eval_type, report, sweep=False, update_viewser=False):
+    def __init__(self, train, evaluate, forecast, saved, run_type, eval_type, report, sweep=False, update_viewser=False, override_timestep=None):
         self.train = train
         self.evaluate = evaluate
         self.forecast = forecast
@@ -27,6 +27,7 @@ class MockArgs:
         self.report = report
         self.sweep = sweep
         self.update_viewser = update_viewser
+        self.override_timestep = override_timestep
 
 @pytest.fixture
 def mock_model_path():
@@ -63,7 +64,8 @@ def mock_constituent_model_path():
                 run_type="test",
                 eval_type="standard",
                 report=False,
-                update_viewser=False
+                update_viewser=False,
+                override_timestep=None
             ),
             [
                 "/path/to/models/test_model/run.sh",
@@ -84,7 +86,8 @@ def mock_constituent_model_path():
                 run_type="forecast",
                 eval_type="detailed",
                 report=False,
-                update_viewser=False
+                update_viewser=False,
+                override_timestep=None
             ),
             [
                 "/path/to/models/test_model/run.sh",
@@ -106,7 +109,8 @@ def mock_constituent_model_path():
                 run_type="calibration",
                 eval_type="minimal",
                 report=False,
-                update_viewser=False
+                update_viewser=False,
+                override_timestep=None
             ),
             [
                 "/path/to/models/test_model/run.sh",
@@ -156,7 +160,8 @@ class TestParametrized:
             args.forecast,
             args.saved,
             args.eval_type,
-            args.update_viewser
+            args.update_viewser,
+            args.override_timestep
         )
         assert command == expected_command
 
@@ -224,6 +229,7 @@ class TestParametrized:
                 use_saved=args.saved,
                 report=args.report,
                 update_viewser=args.update_viewser,
+                override_timestep=args.override_timestep
             )
 
             # Test exception handling
@@ -294,7 +300,8 @@ class TestParametrized:
                 forecast=args.forecast,
                 use_saved=args.saved,
                 report=args.report,
-                update_viewser=args.update_viewser
+                update_viewser=args.update_viewser,
+                override_timestep=args.override_timestep
             )
 
             # Validate W&B metrics (allow multiple calls)
@@ -309,7 +316,7 @@ class TestParametrized:
                 mock_logger.info.assert_any_call(
                     "Training model test_model..."
                 )
-                mock_train_ensemble.assert_called_once_with(use_saved=args.saved, update_viewser=args.update_viewser)
+                mock_train_ensemble.assert_called_once_with(use_saved=args.saved, update_viewser=args.update_viewser, override_timestep=args.override_timestep)
             else:
                 mock_train_ensemble.assert_not_called()
                 # Check for any call with these arguments, ignoring others
@@ -331,7 +338,7 @@ class TestParametrized:
                 mock_logger.info.assert_any_call(
                     "Evaluating model test_model..."
                 )
-                mock_evaluate_ensemble.assert_called_once_with(manager._eval_type, args.update_viewser)
+                mock_evaluate_ensemble.assert_called_once_with(manager._eval_type, args.update_viewser, args.override_timestep)
                 mock_handle_ensemble_log_creation.assert_called()
             else:
                 mock_evaluate_ensemble.assert_not_called()
@@ -346,7 +353,7 @@ class TestParametrized:
                 mock_logger.info.assert_any_call(
                     "Forecasting model test_model..."
                 )
-                mock_forecast_ensemble.assert_called_once_with(update_viewser=args.update_viewser)
+                mock_forecast_ensemble.assert_called_once_with(update_viewser=args.update_viewser, override_timestep=args.override_timestep)
                 mock_handle_ensemble_log_creation.assert_called()
                 mock_save_predictions.assert_called_once_with(
                     mock_forecast_ensemble.return_value,
@@ -386,7 +393,8 @@ class TestParametrized:
                     forecast=args.forecast,
                     use_saved=args.saved,
                     report=args.report,
-                    update_viewser=args.update_viewser
+                    update_viewser=args.update_viewser,
+                    override_timestep=args.override_timestep
                 )
             
             # Validate appropriate error is raised

--- a/tests/test_model_manager.py
+++ b/tests/test_model_manager.py
@@ -75,7 +75,8 @@ def get_deployment_config():
         mock_module.return_value.get_meta_config.return_value = {"meta_key": "meta_value"}
         mm = ModelManager(mock_model_path.return_value, use_prediction_store=False, wandb_notifications=False)
         mm.config = {
-            "targets": "target_variable"
+            "targets": "target_variable",
+            "steps": [*range(1, 36 + 1, 1)],
         }
     return mm
 
@@ -132,7 +133,7 @@ def get_deployment_config():
 """
     mock_config_hyperparameters_content = """
 def get_hp_config():
-    hp_config = {'hp_key': 'hp_value'}
+    hp_config = {'hp_key': 'hp_value', "steps": [*range(1, 36 + 1, 1)]}
     return hp_config
 """
     mock_config_meta_content = """
@@ -205,7 +206,7 @@ def get_deployment_config():
         mock_spec.return_value.loader = MagicMock()
         mock_module.return_value.get_deployment_config.return_value = {"deployment_status": "shadow"}
         manager = ForecastingModelManager(mock_model_instance, use_prediction_store=False)
-        manager._config_hyperparameters = {"hp_key": "hp_value"}
+        manager._config_hyperparameters = {"hp_key": "hp_value", "steps": [*range(1, 36 + 1, 1)]}
         manager._config_meta = {"meta_key": "meta_value", "targets": "test_targets_dep"}
         manager._config_deployment = {"deployment_status": "deploy_value"}
         args = MagicMock(run_type="test_run")

--- a/views_pipeline_core/cli/utils.py
+++ b/views_pipeline_core/cli/utils.py
@@ -78,7 +78,7 @@ def parse_args():
     )
 
     parser.add_argument(
-        "-o", "--override_month", help="Over-ride use of current month", type=int
+        "-o", "--override_timestep", help="Override use of current time (year/month/week/day depending on your LoA)", type=int
     )
 
     parser.add_argument(

--- a/views_pipeline_core/data/dataloaders.py
+++ b/views_pipeline_core/data/dataloaders.py
@@ -1,7 +1,5 @@
 import os
-from dotenv import load_dotenv
-from typing import Dict, Tuple, List, Any
-import ast
+from typing import Dict
 import numpy as np
 import pandas as pd
 import logging
@@ -11,424 +9,11 @@ from views_pipeline_core.configs import drift_detection
 from views_pipeline_core.files.utils import create_data_fetch_log_file
 from views_pipeline_core.data.utils import ensure_float64
 from views_pipeline_core.files.utils import read_dataframe, save_dataframe
-from views_pipeline_core.cli.utils import parse_args
-import argparse
 from views_pipeline_core.configs.pipeline import PipelineConfig
 from views_pipeline_core.managers.model import ModelPathManager
 from ingester3.ViewsMonth import ViewsMonth
 
-# import views_transformation_library as vtl
-import views_transformation_library.views_2 as views2
-# import views_transformation_library.splag4d as splag4d
-import views_transformation_library.missing as missing
-from viewser import Queryset
-import traceback
-# import views_transformation_library.splag_country as splag_country
-# import views_transformation_library.spatial_tree as spatial_tree
-# import views_transformation_library.spacetime_distance as spacetime_distance
-
 logger = logging.getLogger(__name__)
-
-# Ingester dependent imports. Breaks tests on github because no certs
-def _get_splag_country(*args, **kwargs):
-    import views_transformation_library.splag_country as splag_country
-    return splag_country.get_splag_country(*args, **kwargs)
-
-def _get_splag4d(*args, **kwargs):
-    import views_transformation_library.splag4d as splag4d
-    return splag4d.get_splag4d(*args, **kwargs)
-
-def _get_spatial_tree(*args, **kwargs):
-    import views_transformation_library.spatial_tree as spatial_tree
-    return spatial_tree.get_tree_lag(*args, **kwargs)
-
-def _get_spacetime_distance(*args, **kwargs):
-    import views_transformation_library.spacetime_distance as spacetime_distance
-    return spacetime_distance.get_spacetime_distances(*args, **kwargs)
-
-transformation_mapping = {
-    "ops.ln": views2.ln,
-    "missing.fill": missing.fill,
-    "bool.gte": views2.greater_or_equal,
-    "temporal.time_since": views2.time_since,
-    "temporal.decay": views2.decay,
-    "missing.replace_na": missing.replace_na,
-    "spatial.countrylag": _get_splag_country,
-    "temporal.tlag": views2.tlag,
-    "spatial.lag": _get_splag4d,
-    "spatial.treelag": _get_spatial_tree,
-    "spatial.sptime_dist": _get_spacetime_distance,
-    "temporal.moving_sum": views2.moving_sum,
-    "temporal.moving_average": views2.moving_sum,
-}
-
-# The TRANSFORMATIONS_EXPECTING_DF set lists transformation names that require a DataFrame as input,
-# rather than a Series. This is important for handling transformations that operate on multiple columns
-# or require access to the full DataFrame structure. When applying these transformations, the code
-# ensures that the input is converted to a DataFrame before calling the transformation function.
-TRANSFORMATIONS_EXPECTING_DF = {"spatial.lag", "spatial.sptime_dist"}
-
-
-class UpdateViewser:
-    """
-    A class to update VIEWSER dataframes with new GED and ACLED values.
-
-    This class parses a queryset to extract base variable names, transformation sequences, and output variable names.
-    It preprocesses an external update dataframe to align columns and rows with the viewser dataframe, updates raw values,
-    and applies all required transformations as specified in the queryset.
-
-    The workflow:
-    1. Extracts variable and transformation metadata from the queryset.
-    2. Loads and preprocesses the external update dataframe for the specified months.
-    3. Updates the raw columns in the viewser dataframe with new values.
-    4. Applies all transformations to produce the final variables.
-
-    This ensures the viewser dataframe is up-to-date and consistent with the latest external data and transformation logic.
-    """
-
-    def __init__(
-        self,
-        queryset: Queryset,
-        viewser_df: pd.DataFrame,
-        data_path: str | Path,
-        months_to_update: List[int],
-    ):
-        """
-        Initializes the UpdateViewser class with a queryset, a dataframe from viewser (with missed updated),
-        a path to the dataframe with updates from GED & Acled and a list of months to update.
-
-        Args:
-            queryset: The queryset for the respective model.
-            viewser_df: a dataframe from VIEWSER that does not contain the latest updates for GED & Acled data.
-            data_path: the path to the update dataframe with updates for GED and Acled data.
-            months_to_update: A list of months
-
-        This class initializes by extracting the following information from the queryset:
-        - Base_Variables: A list of column names based on the 'from_column' e.g.: 'country_month.ged_sb_best_sum_nokgi'.
-          Columns in the update df have the last part of base_variables as their column names e.g. 'ged_sb_best_sum_nokgi'.
-        - Var_Names: A list of column names after transformations have been applied.
-          Columns in the VIEWSER df have var_names as their column names e.g. 'raw_ged_sb'.
-        - Transformation_list: A list of lists of transformations applied to Base_Variables to produce
-        """
-
-        self.queryset = queryset
-        self.viewser_df = viewser_df
-        self.data_path = Path(data_path)
-        self.months_to_update = list(months_to_update)
-
-        (self.base_variables, self.var_names, self.transformation_list) = (
-            self._extract_from_queryset()
-        )
-
-        if not any(var.startswith("raw_") for var in self.var_names):
-            raise ValueError(
-                "Queryset does not contain any variable staring with raw_. "
-                "At least one raw_ variable is required to update the viewser df."
-            )
-
-        # self.df_external = self._load_update_df()
-        self.df_external = read_dataframe(self.data_path)
-
-        max_month_id_viewser = self.viewser_df.index.get_level_values("month_id").max()
-        max_month_id_external = self.df_external.index.get_level_values(
-            "month_id"
-        ).max()
-        logger.info(f"Max month_id: viewser_df={max_month_id_viewser}")
-        logger.info(f"Max month_id: update_df={max_month_id_external}")
-
-        if max_month_id_viewser > max_month_id_external:
-            raise ValueError(
-                f"Max month_id mismatch: viewser_df={max_month_id_viewser}, "
-                f"update dataframe={max_month_id_external}, "
-                f"Make sure to get the latest update dataframe! "
-            )
-
-        self.result: pd.DataFrame | None = None  # filled by .run()
-
-    def run(self) -> pd.DataFrame:
-        """
-        Function executes all frunctions in the right order to update the dataframe from VIEWSER. Safe to call twice:
-        we memorise the result after first run.
-        """
-        if self.result is not None:
-            logger.debug("Use saved dataframe")  # already done
-            return self.result
-
-        # 1) Adapt update df to queryset and month_ids to update
-        df_update = self._preprocess_update_df()
-
-        # 2) Update df from viewser
-        # df = self.queryset.publish().fetch()
-        self.viewser_df.update(df_update)
-
-        logger.info("Fetched and updated from viewser")
-
-        # 3) Apply transformations
-        df_final = self._apply_all_transformations(df_old=self.viewser_df)
-        logger.info("All transformations done")
-
-        cols_to_drop = df_final.columns[df_final.columns.str.startswith("raw")]
-        df_final = df_final.drop(columns=cols_to_drop)
-
-        # 4)return
-        return df_final
-
-    # 1. -------------  PARSE THE QUERYSET  -------------------------------- #
-    def _extract_from_queryset(
-        self,
-    ) -> Tuple[List[str], List[str], List[List[Dict[str, Any]]]]:
-        """
-        Extracts core information from the queryset that are needed later on for the
-        transformations. For every line in the queryset it records the 'from_column' as
-        Base Variable, 'Column' as Variable Name and all Transformations applied to the Base
-        Variable.
-
-        Outputs: Base Variable, Variable Name and Transformations applied to the Base Variable.
-        """
-        ops = self.queryset.model_dump()["operations"]
-
-        base_variables: list[str] = []
-        var_names: list[str] = []
-        transformation_list: list[list[dict[str, Any]]] = []
-
-        for cand in ops:
-            transformations: list[dict[str, Any]] = []
-
-            for step in cand:
-                match (step["namespace"], step["name"]):
-                    # record variable renames
-                    case ("trf", "util.rename"):
-                        var_names.append(step["arguments"][0])
-
-                    # record other trf-namespace transformations
-                    case ("trf", other) if other != "util.base":
-                        transformations.append(
-                            {
-                                "name": step["name"],
-                                "arguments": step["arguments"],
-                            }
-                        )
-
-                    # record "base variables"
-                    case ("base", _):
-                        base_variables.append(step["name"])
-
-            transformations.reverse()
-            transformation_list.append(transformations)
-
-        return base_variables, var_names, transformation_list
-    
-    # 2. ------------  PREPROCESS THE UPDATE DF  ---------- #
-    def _preprocess_update_df(
-        self, *, overwrite_external: bool = False
-    ) -> pd.DataFrame:
-        """
-        Processes the external update dataframe (`self.df_external`) to align it with the variables and months required for updating the viewser dataframe.
-
-        Steps:
-        1. Extracts the base variable names from the queryset, removing any LOA prefixes (e.g., 'country_month.ged_sb_best_sum_nokgi' → 'ged_sb_best_sum_nokgi').
-        2. Identifies which base variables have corresponding updates in the external dataframe (overlap).
-        3. Filters the external dataframe to retain only the overlapping columns.
-        4. Selects only the rows for the specified `months_to_update`.
-        5. Builds a mapping from base variable names to their corresponding raw variable names in the viewser dataframe (e.g., 'ged_sb_best_sum_nokgi' → 'raw_ged_sb').
-        6. Renames the columns in the update dataframe using this mapping so they match the viewser dataframe.
-        7. Optionally replaces `self.df_external` with the processed dataframe if `overwrite_external` is True.
-
-        Parameters
-        ----------
-        overwrite_external : bool, default False
-            If True, replaces self.df_external with the processed result.
-
-        Returns
-        -------
-        pd.DataFrame
-            The processed and aligned update dataframe, ready to be used for updating the viewser dataframe.
-        """
-
-        df_new = self.df_external
-
-        # 1. For each string in self.base_variables (which are typically fully-qualified variable names like 'country_month.ged_sb_best_sum_nokgi'),
-        #    it splits the string at the last period ('.') and takes the part after the period. If there is no period, it uses the whole string.
-        #    This produces a list of "base" variable names (e.g., 'ged_sb_best_sum_nokgi') that match the column names in the external update dataframe.
-        #
-        # 2. It then computes the intersection between these extracted base variable names and the columns present in df_new (the external update dataframe).
-        #    This ensures that only variables present in both the queryset and the update dataframe are considered for further processing.
-        #
-        # 3. Finally, it creates a new dataframe (combined_subset) containing only the columns from df_new that are present in the overlap set.
-        #    This filters the external dataframe down to just the relevant columns that can be used for updating the viewser dataframe.
-        # This is dangerous!
-        last_parts = [
-            s.rsplit(".", 1)[1] if "." in s else s for s in self.base_variables
-        ]
-        overlap = set(last_parts).intersection(df_new.columns)
-        if not overlap:
-            raise ValueError(
-                "No overlapping columns found between base variables and update dataframe. "
-                "Check if the update dataframe contains the expected columns."
-            )  # D: Check if the update dataframe contains the expected columns.
-
-        combined_subset = df_new[list(overlap)]
-
-        # ------------------------------------- #
-        # 2. keep only the requested months
-        #    (assumes month_id is the index; adapt otherwise)
-        # ------------------------------------- #
-        df_new = combined_subset.loc[self.months_to_update]
-
-        # ------------------------------------- #
-        # 3. build the rename map (raw_* only)
-        # ------------------------------------- #
-        matching: dict[str, str] = {}
-        for last, vname in zip(last_parts, self.var_names):
-            if vname.startswith("raw_"):
-                matching[last] = vname
-            # else: transformed -- ignore for renaming
-
-        self.last_parts = last_parts
-        self.matching = matching
-
-        df_new = df_new.rename(columns=matching)
-
-        # ------------------------------------- #
-        # 4. optionally persist inside the object
-        # ------------------------------------- #
-        if overwrite_external:
-            self.df_external = df_new
-
-        return df_new
-
-    def _smart_cast(self, arg):
-        """
-        Safely converts a string representation of a Python literal to its corresponding Python object.
-
-        Attempts to evaluate the input `arg` using `ast.literal_eval`, which can parse valid Python literals
-        such as numbers, lists, dictionaries, booleans, etc. If the evaluation is successful, returns the
-        resulting Python object. If the input is not a valid literal or is already a non-string type,
-        returns the original argument unchanged.
-
-        Args:
-            arg: The input to be converted, typically a string representation of a Python literal.
-
-        Returns:
-            The evaluated Python object if conversion is successful; otherwise, the original input.
-        """
-        try:
-            return ast.literal_eval(arg)
-        except Exception:
-            return arg
-
-    # 3. ------------  APPLY THE TRANSFORMATIONS  ------------------------- #
-    def _apply_all_transformations(self, df_old: pd.DataFrame) -> pd.DataFrame:
-        """
-        Applies all required transformations to GED/ACLED variables as described in the queryset.
-
-        For each variable:
-        - Skips non-GED/ACLED and raw variables.
-        - Applies the sequence of transformations in the correct order.
-        - Handles special cases (e.g., spatial.countrylag).
-        - Ensures index alignment after transformation.
-        - Assigns the final transformed series to the output DataFrame.
-
-        Operates in-place on `df_old` and returns it.
-        """
-        ix = pd.IndexSlice
-
-        # Detect the group level (e.g., pg_id, country_id)
-        group_level = next(
-            (lvl for lvl in df_old.index.names if lvl != "month_id"), None
-        )
-        if not group_level:
-            raise ValueError("Could not determine group level from MultiIndex")
-
-        for idx, (var_name, transformations) in enumerate(
-            zip(self.var_names, self.transformation_list)
-        ):
-            # Skip non-ged/acled variables
-            if not any(prefix in var_name for prefix in ("ged", "acled")):
-                logger.debug(f"No Acled or GED variable: {var_name}")
-                continue
-
-            # Skip raw variables
-            if var_name.startswith("raw_"):
-                logger.debug(f"Raw Variable: {var_name}")
-                continue
-
-            # Skip if no transformations to apply
-            if not transformations:
-                logger.debug(f"No transformations: {var_name}")
-                continue
-
-            # Correctly fetch base variable
-            base_var_key = self.last_parts[idx]
-            base_var = self.matching.get(base_var_key)
-
-            if not base_var:
-                logger.warning(
-                    f"⚠️ Could not find base_var for {var_name} (from key '{base_var_key}')"
-                )
-                continue
-            if base_var not in df_old.columns:
-                logger.warning(
-                    f"⚠️ base_var '{base_var}' not in df_old.columns for {var_name}"
-                )
-                continue
-
-            current_series = df_old[base_var]
-
-            for transformation in transformations:
-                name = transformation["name"]
-
-                # args = list(map(int, transformation.get("arguments", [])))
-                # args = [smart_cast(arg) for arg in transformation.get("arguments", [])]
-                # args = transformation.get("arguments", [])
-                args = [
-                    self._smart_cast(arg) for arg in transformation.get("arguments", [])
-                ]
-                transform_func = transformation_mapping.get(name)
-
-                if not transform_func:
-                    raise ValueError(f"Unknown transformation: {name}")
-
-                logger.info(
-                    f"Applying transformation {name} with args {args} to {var_name}"
-                )
-
-                # Special case: spatial.countrylag
-                if name == "spatial.countrylag":
-                    logger.debug(f"Special transformation: {name}")
-                    ffilled_col = current_series.groupby(level=group_level).ffill()
-                    df_old.loc[ix[self.months_to_update, :], var_name] = (
-                        ffilled_col.loc[ix[self.months_to_update, :]]
-                    )
-                    continue
-
-                # Determine input shape: Series vs DataFrame
-                if name in TRANSFORMATIONS_EXPECTING_DF:
-                    input_data = current_series.to_frame()
-                else:
-                    input_data = current_series
-
-                # Apply transformation
-                try:
-                    current_series = (
-                        transform_func(input_data, *args)
-                        if args
-                        else transform_func(input_data)
-                    )
-                except Exception as e:
-                    raise RuntimeError(f"Error applying {name} to {var_name}: {e}")
-
-                # Optional: ensure index matches to prevent NaNs
-                if not current_series.index.equals(df_old.index):
-                    logger.warning(
-                        f"[WARNING] Index mismatch after {name} → reindexing"
-                    )
-                    current_series = current_series.reindex(df_old.index)
-
-            # Final assignment to df
-            df_old[var_name] = current_series
-
-        return df_old
 
 
 class ViewsDataLoader:
@@ -439,13 +24,7 @@ class ViewsDataLoader:
     create or load volumes, and handle drift detection configurations.
     """
 
-    def __init__(
-        self,
-        model_path: ModelPathManager,
-        partition_dict: Dict = None,
-        steps: int = 36,
-        **kwargs,
-    ):
+    def __init__(self, model_path: ModelPathManager, partition_dict: Dict = None, steps: int = 36, **kwargs):
         """
         Initializes the DataLoaders class with a ModelPathManager object and optional keyword arguments.
 
@@ -496,17 +75,18 @@ class ViewsDataLoader:
             - For the "forecasting" partition, the train range starts at 121 and ends at the current month minus 2.
               The predict range starts at the current month minus 1 and extends by the step size.
         """
-        logger.warning(
-            "Did not use config_partitions.py, using default partition dictionary instead..."
-        )
+        logger.warning("Did not use config_partitions.py, using default partition dictionary instead...")
         match self.partition:
             case "calibration":
                 return {
                     "train": (121, 396),
                     "test": (397, 444),
-                }  # calib_partitioner_dict - (01/01/1990 - 12/31/2012) : (01/01/2013 - 31/12/2015)
+                    }  # calib_partitioner_dict - (01/01/1990 - 12/31/2012) : (01/01/2013 - 31/12/2015)
             case "validation":
-                return {"train": (121, 444), "test": (445, 492)}
+                return {
+                    "train": (121, 444), 
+                    "test": (445, 492)
+                    }
             case "forecasting":
                 month_last = (
                     ViewsMonth.now().id - 2
@@ -514,104 +94,12 @@ class ViewsDataLoader:
                 return {
                     "train": (121, month_last),
                     "test": (month_last + 1, month_last + 1 + steps),
-                }
+                }  
             case _:
                 raise ValueError(
                     'partition should be either "calibration", "validation" or "forecasting"'
                 )
         pass
-
-    def _get_viewser_update_config(self, queryset_base: Queryset) -> tuple[int, str]:
-        """
-        Retrieves the update configuration for the viewser dataset based on the provided queryset.
-
-        This method:
-        - Locates and loads the `.env` file from the project root.
-        - Extracts the list of months to update from the environment variable.
-        - Determines the update file path according to the queryset's level of analysis (LOA).
-
-        Args:
-            queryset_base (Queryset): The queryset object, expected to have a `model_dump()` method with an 'loa' key.
-
-        Returns:
-            tuple[list[int], str | None]: A tuple containing the months to update (as a list of ints)
-                          and the update file path (str or None if LOA is unknown).
-
-        Raises:
-            FileNotFoundError: If the `.env` file is not found.
-            RuntimeError: If the `.env` file cannot be loaded.
-        """
-        dotenv_path = self._model_path.find_project_root() / ".env"
-        logger.debug(f"Path to dotenv file: {dotenv_path}")
-
-        if not dotenv_path.exists():
-            raise FileNotFoundError(f"Required .env file not found: {dotenv_path}")
-
-        if not load_dotenv(dotenv_path=dotenv_path):
-            raise RuntimeError(
-                f".env file found but could not be loaded: {dotenv_path}"
-            )
-
-        # months_to_update = PipelineConfig().months_to_update #read from .env
-        months_to_update_str = os.getenv("month_to_update")
-        if not months_to_update_str or months_to_update_str is "":
-            raise ValueError("Could not find months to update in the .env file. Add the line: month_to_update=[123, 124, 125]")
-
-        months_to_update = ast.literal_eval(months_to_update_str)
-        logger.debug(f"Months to update: {months_to_update}")
-
-        loa_qs = queryset_base.model_dump()["loa"]
-        logger.debug(f"Level of Analysis: {loa_qs}")
-
-        if loa_qs == "priogrid_month":
-            update_path = os.getenv("pgm_path")
-        elif loa_qs == "country_month":
-            update_path = os.getenv("cm_path")
-        else:
-            logger.warning("Unknown LOA; no update path set")
-            update_path = None
-
-        logger.debug(f"Update path: {update_path}")
-        return months_to_update, update_path
-
-    def _overwrite_viewser(
-        self, df: pd.DataFrame, queryset_base: Queryset, args: argparse.Namespace
-    ) -> pd.DataFrame:
-        """
-        Updates the provided DataFrame using the Viewser update process if specified in the arguments.
-
-        If `args.update_viewser` is True, this method retrieves the update configuration,
-        initializes an UpdateViewser instance, and updates the DataFrame accordingly.
-        Logs the update process and the number of NaN values after transformation.
-        If updating is not requested, logs that the DataFrame has not been updated.
-
-        Args:
-            df (pd.DataFrame): The DataFrame to potentially update.
-            queryset_base (Any): The base queryset used for configuration and updating.
-            args (Namespace): Arguments containing the `update_viewser` flag.
-
-        Returns:
-            pd.DataFrame: The (possibly updated) DataFrame.
-        """
-        if args.update_viewser:
-            logger.info(
-                "Overwriting Viewser dataframe with new values from GED and ACLED"
-            )
-            months_to_update, update_path = self._get_viewser_update_config(
-                queryset_base
-            )
-            builder = UpdateViewser(
-                queryset_base,
-                viewser_df=df,
-                data_path=update_path,
-                months_to_update=months_to_update,
-            )
-            df = builder.run()
-            logger.info("Viewser dataframe updated")
-            logger.debug(f"NaNs in df after transformations: {df.isna().sum()}")
-        else:
-            logger.info("Viewser dataframe will not be overwritten")
-        return df
 
     def _fetch_data_from_viewser(self, self_test: bool) -> tuple[pd.DataFrame, list]:
         """
@@ -633,15 +121,12 @@ class ViewsDataLoader:
         )
 
         queryset_base = self._model_path.get_queryset()  # just used here..
-
         if queryset_base is None:
-            raise RuntimeError(f"Could not find queryset for {self._model_name}")
+            raise RuntimeError(
+                f"Could not find queryset for {self._model_name}"
+            )
         else:
             logger.info(f"Found queryset for {self._model_name}")
-
-        args = parse_args()
-        # dotenv_path = self._model_path.find_project_root()/ 'ensembles' / '.env'
-        df, alerts = None, None
 
         try:
             df, alerts = queryset_base.publish().fetch_with_drift_detection(
@@ -650,37 +135,28 @@ class ViewsDataLoader:
                 drift_config_dict=self.drift_config_dict,
                 self_test=self_test,
             )
-
             for ialert, alert in enumerate(
-                str(alerts).strip("[").strip("]").split("Input")
-            ):
+            str(alerts).strip("[").strip("]").split("Input")):
                 if "offender" in alert:
                     logger.warning(
-                        {
-                            f"{self._model_path.model_name} data alert {ialert}": str(
-                                alert
-                            )
-                        }
+                        {f"{self._model_path.model_name} data alert {ialert}": str(alert)}
                     )
-            # df = self._overwrite_viewser(df, queryset_base, args)
-            # df = ensure_float64(df)
+            df = ensure_float64(df)
+            return df, alerts
         except KeyError as e:
-            logger.error(
-                f"\033[91mError fetching data from viewser: {e}. Trying to fetch without drift detection.\033[0m",
-                exc_info=True,
-            )
+            logger.error(f"\033[91mError fetching data from viewser: {e}. Trying to fetch without drift detection.\033[0m", exc_info=True)
             df = queryset_base.publish().fetch(
                 start_date=self.month_first,
                 end_date=self.month_last - 1,
             )
+            df = ensure_float64(df)
+            return df, None
         except Exception as e:
             logger.error(f"Error fetching data from viewser: {e}", exc_info=True)
-            logger.error(traceback.format_exc())
-            raise RuntimeError(f"Error fetching data from viewser: {e}") from e
-        
-        df = self._overwrite_viewser(df, queryset_base, args)
-        df = ensure_float64(df)
-        return df, alerts
+            raise RuntimeError(
+                f"Error fetching data from viewser: {e}"
+            )
+
 
     def _get_month_range(self) -> tuple[int, int]:
         """
@@ -710,7 +186,9 @@ class ViewsDataLoader:
 
         return month_first, month_last
 
-    def _validate_df_partition(self, df: pd.DataFrame) -> bool:
+    def _validate_df_partition(
+        self, df: pd.DataFrame
+    ) -> bool:
         """
         Checks to see if the min and max months in the input dataframe are the same as the min
         month in the train and max month in the predict portions (or min and max months in the train portion for
@@ -789,30 +267,18 @@ class ViewsDataLoader:
         Raises:
             RuntimeError: If the saved data file is not found or if the data is incompatible with the partition.
         """
-        self.partition = partition  # if self.partition is None else self.partition
-        # self.partition_dict = (
-        #     self._get_partition_dict(steps=self.steps)
-        #     if self.partition_dict is None
-        #     else self.partition_dict.get(partition, None)
-        # )
-        self.partition_dict = self.partition_dict.get(partition, None)
-        self.drift_config_dict = (
-            drift_detection.drift_detection_partition_dict[partition]
-            if self.drift_config_dict is None
-            else self.drift_config_dict
-        )
-        self.override_month = (
-            override_month if self.override_month is None else override_month
-        )
+        self.partition = partition #if self.partition is None else self.partition
+        self.partition_dict = self._get_partition_dict(steps=self.steps) if self.partition_dict is None else self.partition_dict.get(partition, None)
+        self.drift_config_dict = drift_detection.drift_detection_partition_dict[
+            partition
+        ] if self.drift_config_dict is None else self.drift_config_dict
+        self.override_month = override_month if self.override_month is None else override_month
         if self.month_first is None or self.month_last is None:
             self.month_first, self.month_last = self._get_month_range()
 
         path_viewser_df = Path(
-            os.path.join(
-                str(self._path_raw),
-                f"{self.partition}_viewser_df{PipelineConfig.dataframe_format}",
-            )
-        )
+            os.path.join(str(self._path_raw), f"{self.partition}_viewser_df{PipelineConfig.dataframe_format}")
+        )  
         alerts = None
 
         if use_saved:
@@ -825,29 +291,24 @@ class ViewsDataLoader:
                         f"Use of saved data was specified but getting {path_viewser_df} failed with: {e}"
                     )
             else:
-                logger.info(
-                    f"Saved data not found at {path_viewser_df}, fetching from viewser..."
-                )
+                logger.info(f"Saved data not found at {path_viewser_df}, fetching from viewser...")
                 df, alerts = self._fetch_data_from_viewser(self_test)
                 data_fetch_timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
                 create_data_fetch_log_file(
-                    self._path_raw,
-                    self.partition,
-                    self._model_name,
-                    data_fetch_timestamp,
+                    self._path_raw, self.partition, self._model_name, data_fetch_timestamp
                 )
                 logger.info(f"Saving data to {path_viewser_df}")
                 save_dataframe(df, path_viewser_df)
         else:
             logger.info(f"Fetching data from viewser...")
-            df, alerts = self._fetch_data_from_viewser(self_test)
+            df, alerts = self._fetch_data_from_viewser(self_test) 
             data_fetch_timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
             create_data_fetch_log_file(
                 self._path_raw, self.partition, self._model_name, data_fetch_timestamp
             )
             logger.info(f"Saving data to {path_viewser_df}")
             save_dataframe(df, path_viewser_df)
-
+            
         if validate:
             if self._validate_df_partition(df=df):
                 return df, alerts
@@ -868,3 +329,4 @@ class ViewsDataLoader:
         #     df = df.set_index(["month_id", "priogrid_id"])
 
         return df, alerts
+    

--- a/views_pipeline_core/data/dataloaders.py
+++ b/views_pipeline_core/data/dataloaders.py
@@ -89,7 +89,7 @@ class ViewsDataLoader:
                     }
             case "forecasting":
                 month_last = (
-                    ViewsMonth.now().id - 2
+                    ViewsMonth.now().id - 1
                 )  # minus 2 because the current month is not yet available. Verified but can be tested by changing this and running the check_data notebook.
                 return {
                     "train": (121, month_last),
@@ -131,7 +131,7 @@ class ViewsDataLoader:
         try:
             df, alerts = queryset_base.publish().fetch_with_drift_detection(
                 start_date=self.month_first,
-                end_date=self.month_last - 1,
+                end_date=self.month_last,
                 drift_config_dict=self.drift_config_dict,
                 self_test=self_test,
             )
@@ -147,7 +147,7 @@ class ViewsDataLoader:
             logger.error(f"\033[91mError fetching data from viewser: {e}. Trying to fetch without drift detection.\033[0m", exc_info=True)
             df = queryset_base.publish().fetch(
                 start_date=self.month_first,
-                end_date=self.month_last - 1,
+                end_date=self.month_last,
             )
             df = ensure_float64(df)
             return df, None
@@ -156,7 +156,6 @@ class ViewsDataLoader:
             raise RuntimeError(
                 f"Error fetching data from viewser: {e}"
             )
-
 
     def _get_month_range(self) -> tuple[int, int]:
         """
@@ -171,9 +170,9 @@ class ViewsDataLoader:
         month_first = self.partition_dict["train"][0]
 
         if self.partition == "forecasting":
-            month_last = self.partition_dict["train"][1] + 1
+            month_last = self.partition_dict["train"][1]
         elif self.partition in ["calibration", "validation"]:
-            month_last = self.partition_dict["test"][1] + 1
+            month_last = self.partition_dict["test"][1]
         else:
             raise ValueError(
                 'partition should be either "calibration", "validation" or "forecasting"'
@@ -215,27 +214,27 @@ class ViewsDataLoader:
             first_month = self.partition_dict["train"][0]
             last_month = self.partition_dict["train"][1]
             if self.override_month is not None:
-                last_month = self.override_month - 1
+                last_month = self.override_month
         if [np.min(df_time_units), np.max(df_time_units)] != [first_month, last_month]:
             return False
         else:
             return True
 
-    @staticmethod
-    def filter_dataframe_by_month_range(self, df: pd.DataFrame) -> pd.DataFrame:
-        """
-        Filters the DataFrame to include only the specified month range.
+    # @staticmethod
+    # def filter_dataframe_by_month_range(self, df: pd.DataFrame) -> pd.DataFrame:
+    #     """
+    #     Filters the DataFrame to include only the specified month range.
 
-        Args:
-            df (pd.DataFrame): The input DataFrame to be filtered.
-            month_first (int): The first month ID to include.
-            month_last (int): The last month ID to include.
+    #     Args:
+    #         df (pd.DataFrame): The input DataFrame to be filtered.
+    #         month_first (int): The first month ID to include.
+    #         month_last (int): The last month ID to include.
 
-        Returns:
-            pd.DataFrame: The filtered DataFrame.
-        """
-        month_range = np.arange(self.month_first, self.month_last)
-        return df[df["month_id"].isin(month_range)].copy()
+    #     Returns:
+    #         pd.DataFrame: The filtered DataFrame.
+    #     """
+    #     month_range = np.arange(self.month_first, self.month_last)
+    #     return df[df["month_id"].isin(month_range)].copy()
 
     def get_data(
         self,

--- a/views_pipeline_core/data/dataloaders.py
+++ b/views_pipeline_core/data/dataloaders.py
@@ -181,7 +181,7 @@ class ViewsDataLoader:
         if self.partition == "forecasting" and self.override_month is not None:
             month_last = self.override_month
             logger.warning(
-                f"Overriding end month in forecasting partition to {month_last} ***\n"
+                f"Overriding end month in forecasting partition to {month_last}\n"
             )
 
         return month_first, month_last

--- a/views_pipeline_core/managers/ensemble.py
+++ b/views_pipeline_core/managers/ensemble.py
@@ -322,7 +322,7 @@ class EnsembleManager(ForecastingModelManager):
 
         if override_timestep is not None:
             shell_command.append("--override_timestep")
-            shell_command.append(int(override_timestep))
+            shell_command.append(str(override_timestep))
 
         return shell_command
 
@@ -421,6 +421,7 @@ class EnsembleManager(ForecastingModelManager):
                 use_saved=args.saved,
                 report=args.report,
                 update_viewser=args.update_viewser,
+                override_timestep=args.override_timestep,
             )
         except Exception as e:
             logger.error(
@@ -445,6 +446,7 @@ class EnsembleManager(ForecastingModelManager):
         use_saved: bool,
         report: bool,
         update_viewser: bool,
+        override_timestep: Optional[int] = None,
     ) -> None:
         """
         Executes various model-related tasks including training, evaluation, and forecasting.
@@ -455,7 +457,9 @@ class EnsembleManager(ForecastingModelManager):
             eval (bool): Flag to indicate if the model should be evaluated.
             forecast (bool): Flag to indicate if forecasting should be performed.
             use_saved (bool): Flag to indicate if saved models should be used.
-
+            report (bool): Flag to indicate if reporting should be performed.
+            update_viewser (bool): Flag to indicate if the viewser should be updated.
+            override_timestep (int): If provided, overrides the timestamp for the last available data.
         Raises:
         Exception: If any error occurs during training, evaluation, or forecasting, it is logged and re-raised.
 
@@ -466,11 +470,11 @@ class EnsembleManager(ForecastingModelManager):
         start_t = time.time()
 
         if train:
-            self._execute_model_training(config, use_saved, update_viewser)
+            self._execute_model_training(config, use_saved, update_viewser, override_timestep)
         if eval:
-            self._execute_model_evaluation(config, update_viewser)
+            self._execute_model_evaluation(config, update_viewser, override_timestep)
         if forecast:
-            self._execute_model_forecasting(config, update_viewser)
+            self._execute_model_forecasting(config, update_viewser, override_timestep)
         if report and forecast:
             self._execute_forecast_reporting(config)
         if report and eval:
@@ -483,7 +487,7 @@ class EnsembleManager(ForecastingModelManager):
         logger.info(f"Done. Runtime: {minutes:.3f} minutes.\n")
 
     def _execute_model_training(
-        self, config: dict, use_saved: bool, update_viewser: bool
+        self, config: dict, use_saved: bool, update_viewser: bool, override_timestep: Optional[int] = None
     ) -> None:
         """
         Executes the model training process.
@@ -491,7 +495,8 @@ class EnsembleManager(ForecastingModelManager):
         Args:
             config (dict): Configuration object containing parameters and settings.
             use_saved (bool): Flag to indicate if saved data should be used.
-
+            update_viewser (bool): Flag to indicate if the viewser should be updated.
+            override_timestep (int): If provided, overrides the timestamp for the last available data.
         Returns:
             None
         """
@@ -501,7 +506,7 @@ class EnsembleManager(ForecastingModelManager):
             add_wandb_metrics()
             try:
                 logger.info(f"Training model {config['name']}...")
-                self._train_ensemble(use_saved=use_saved, update_viewser=update_viewser)
+                self._train_ensemble(use_saved=use_saved, update_viewser=update_viewser, override_timestep=override_timestep)
 
                 wandb_alert(
                     title=f"Training for {self._model_path.target} {config['name']} completed successfully.",
@@ -523,7 +528,7 @@ class EnsembleManager(ForecastingModelManager):
                 )
                 raise
 
-    def _execute_model_evaluation(self, config: dict, update_viewser: bool) -> None:
+    def _execute_model_evaluation(self, config: dict, update_viewser: bool, override_timestep: Optional[int] = None) -> None:
         """
         Executes the model evaluation process within a Weights & Biases (wandb) run context.
 
@@ -533,7 +538,7 @@ class EnsembleManager(ForecastingModelManager):
 
             config (dict): Configuration object containing parameters and settings for the evaluation.
             update_viewser (bool): Flag indicating whether to update the viewser during evaluation.
-
+            override_timestep (int): If provided, overrides the timestamp for the last available data.
         Raises:
             Exception: Propagates any exception that occurs during the evaluation process after logging and sending an alert.
 
@@ -556,7 +561,7 @@ class EnsembleManager(ForecastingModelManager):
             try:
                 logger.info(f"Evaluating model {config['name']}...")
                 df_predictions = self._evaluate_ensemble(
-                    self._eval_type, update_viewser
+                    self._eval_type, update_viewser, override_timestep
                 )
 
                 handle_ensemble_log_creation(model_path=self._model_path, config=config)
@@ -585,7 +590,7 @@ class EnsembleManager(ForecastingModelManager):
                 )
                 raise
 
-    def _execute_model_forecasting(self, config: dict, update_viewser: bool) -> None:
+    def _execute_model_forecasting(self, config: dict, update_viewser: bool, override_timestep: Optional[int] = None) -> None:
         """
         Executes the model forecasting process within a Weights & Biases (wandb) run context.
 
@@ -594,6 +599,8 @@ class EnsembleManager(ForecastingModelManager):
         In case of errors during forecasting, it logs the error, sends an alert, and re-raises the exception.
 
             config (dict): Configuration object containing parameters and settings for the forecasting process.
+            update_viewser (bool): Flag indicating whether to update the viewser during forecasting.
+            override_timestep (int): If provided, overrides the timestamp for the last available data.
 
 
         Raises:
@@ -615,7 +622,7 @@ class EnsembleManager(ForecastingModelManager):
             add_wandb_metrics()
             try:
                 logger.info(f"Forecasting model {config['name']}...")
-                df_prediction = self._forecast_ensemble(update_viewser=update_viewser)
+                df_prediction = self._forecast_ensemble(update_viewser=update_viewser, override_timestep=override_timestep)
 
                 wandb_alert(
                     title=f"Forecasting for {self._model_path.target} {config['name']} completed successfully.",

--- a/views_pipeline_core/managers/ensemble.py
+++ b/views_pipeline_core/managers/ensemble.py
@@ -279,6 +279,7 @@ class EnsembleManager(ForecastingModelManager):
         update_viewser: bool = False,
         prediction_store: bool = False,
         wandb_notifications: bool = False,
+        override_timestep: Optional[int] = None,
     ) -> list:
         """
         Constructs a shell command for running a model script with specified options.
@@ -318,6 +319,10 @@ class EnsembleManager(ForecastingModelManager):
 
         shell_command.append("--eval_type")
         shell_command.append(eval_type)
+
+        if override_timestep is not None:
+            shell_command.append("--override_timestep")
+            shell_command.append(int(override_timestep))
 
         return shell_command
 
@@ -634,7 +639,7 @@ class EnsembleManager(ForecastingModelManager):
                 )
                 raise
 
-    def _train_ensemble(self, use_saved: bool, update_viewser: bool) -> None:
+    def _train_ensemble(self, use_saved: bool, update_viewser: bool, override_timestep: Optional[int] = None) -> None:
         """
         Trains an ensemble of models specified in the configuration.
 
@@ -649,11 +654,11 @@ class EnsembleManager(ForecastingModelManager):
         for model_name in tqdm.tqdm(self.config["models"], desc="Training ensemble"):
             tqdm.tqdm.write(f"Current model: {model_name}")
             self._train_model_artifact(
-                model_name, run_type, use_saved, update_viewser=update_viewser
+                model_name, run_type, use_saved, update_viewser=update_viewser, override_timestep=override_timestep
             )
 
     def _evaluate_ensemble(
-        self, eval_type: str, update_viewser: bool
+        self, eval_type: str, update_viewser: bool, override_timestep: Optional[int] = None
     ) -> List[pd.DataFrame]:
         """
         Evaluates the ensemble of models based on the specified evaluation type.
@@ -675,7 +680,7 @@ class EnsembleManager(ForecastingModelManager):
             tqdm.tqdm.write(f"Current model: {model_name}")
             dfs.append(
                 self._evaluate_model_artifact(
-                    model_name, run_type, eval_type, update_viewser
+                    model_name, run_type, eval_type, update_viewser, override_timestep
                 )
             )
 
@@ -689,7 +694,7 @@ class EnsembleManager(ForecastingModelManager):
 
         return dfs_agg
 
-    def _forecast_ensemble(self, update_viewser: bool) -> None:
+    def _forecast_ensemble(self, update_viewser: bool, override_timestep: Optional[int] = None) -> None:
         """
          Generates ensemble forecasts by iterating over the models specified in the configuration, aggregates their results, and optionally reconciles the predictions.
 
@@ -715,7 +720,7 @@ class EnsembleManager(ForecastingModelManager):
         ):
             tqdm.tqdm.write(f"Current model: {model_name}")
             dfs.append(
-                self._forecast_model_artifact(model_name, run_type, update_viewser)
+                self._forecast_model_artifact(model_name, run_type, update_viewser, override_timestep)
             )
 
         df_prediction = EnsembleManager._get_aggregated_df(
@@ -775,6 +780,7 @@ class EnsembleManager(ForecastingModelManager):
         update_viewser: bool = False,
         prediction_store: bool = False,
         wandb_notifications: bool = False,
+        override_timestep: Optional[int] = None,
     ) -> None:
         """
         Executes a shell script for a model artifact.
@@ -791,6 +797,7 @@ class EnsembleManager(ForecastingModelManager):
             update_viewser (bool, optional): Whether to update the viewser dataframe. Defaults to False.
             prediction_store (bool, optional): Whether to use the prediction store. Defaults to False.
             wandb_notifications (bool, optional): Whether to send notifications to Weights & Biases. Defaults to False.
+            override_timestep (Optional[int], optional): Timestep to override. Defaults to None.
 
         Raises:
             Exception: If an error occurs during the execution of the shell command.
@@ -811,6 +818,7 @@ class EnsembleManager(ForecastingModelManager):
             update_viewser=update_viewser,
             prediction_store=prediction_store,
             wandb_notifications=wandb_notifications,
+            override_timestep=override_timestep,
         )
 
         try:
@@ -823,7 +831,7 @@ class EnsembleManager(ForecastingModelManager):
             raise
 
     def _train_model_artifact(
-        self, model_name: str, run_type: str, use_saved: bool, update_viewser: bool
+        self, model_name: str, run_type: str, use_saved: bool, update_viewser: bool, override_timestep: Optional[int] = None,
     ) -> None:
         """
         Trains a single model artifact.
@@ -852,10 +860,11 @@ class EnsembleManager(ForecastingModelManager):
             use_saved=use_saved,
             update_viewser=update_viewser,
             wandb_notifications=self._wandb_notifications,
+            override_timestep=override_timestep
         )
 
     def _evaluate_model_artifact(
-        self, model_name: str, run_type: str, eval_type: str, update_viewser: bool
+        self, model_name: str, run_type: str, eval_type: str, update_viewser: bool, override_timestep: Optional[int] = None
     ) -> List[pd.DataFrame]:
         """
         Evaluate a model artifact by loading or generating predictions.
@@ -933,6 +942,7 @@ class EnsembleManager(ForecastingModelManager):
                         eval_type=eval_type,
                         update_viewser=update_viewser,
                         wandb_notifications=self._wandb_notifications,
+                        override_timestep=override_timestep
                     )
                     pred = read_dataframe(
                         f"{path_generated}/predictions_{run_type}_{ts}_{str(sequence_number).zfill(2)}{PipelineConfig().dataframe_format}"
@@ -943,7 +953,7 @@ class EnsembleManager(ForecastingModelManager):
         return preds
 
     def _forecast_model_artifact(
-        self, model_name: str, run_type: str, update_viewser: bool
+        self, model_name: str, run_type: str, update_viewser: bool, override_timestep: Optional[int] = None
     ) -> pd.DataFrame:
         """
         Forecasts a model artifact and returns the predictions as a DataFrame.
@@ -991,6 +1001,7 @@ class EnsembleManager(ForecastingModelManager):
                     update_viewser=update_viewser,
                     prediction_store=self._use_prediction_store,
                     wandb_notifications=self._wandb_notifications,
+                    override_timestep=override_timestep
                 )
                 pred = pd.DataFrame.forecasts.read_store(
                     run=self._pred_store_name, name=name

--- a/views_pipeline_core/managers/model.py
+++ b/views_pipeline_core/managers/model.py
@@ -1442,6 +1442,11 @@ class ForecastingModelManager(ModelManager):
             **self._config_deployment,
         }
         if hasattr(self, "_partition_dict") and self._partition_dict is not None:
+            if args.override_timestep is not None:
+                self._partition_dict["forecasting"] = {
+                    "train": (121, args.override_timestep),
+                    "test": (args.override_timestep + 1, args.override_timestep + 1 + len(config["steps"])),
+                } # Refactor this later
             config.update(self._partition_dict)
         config["run_type"] = args.run_type
         config["eval_type"] = args.eval_type

--- a/views_pipeline_core/managers/model.py
+++ b/views_pipeline_core/managers/model.py
@@ -1086,6 +1086,7 @@ class ForecastingModelManager(ModelManager):
                 validate=True,
                 self_test=args.drift_self_test,
                 partition=args.run_type,
+                override_month=args.override_timestep
             )
 
             current_month = datetime.now().strftime("%Y-%m")
@@ -1116,11 +1117,11 @@ class ForecastingModelManager(ModelManager):
                         "created_at": datetime.now().isoformat(),
                     },
                 )
-                artifact_raw_data.add_file(
-                    self._model_path.data_raw
-                    / f"{args.run_type}_viewser_df{PipelineConfig().dataframe_format}"
-                )
-                wandb.run.log_artifact(artifact_raw_data)
+                # artifact_raw_data.add_file(
+                #     self._model_path.data_raw
+                #     / f"{args.run_type}_viewser_df{PipelineConfig().dataframe_format}"
+                # )
+                # wandb.run.log_artifact(artifact_raw_data)
 
             finally:
                 wandb.finish()

--- a/views_pipeline_core/templates/ensemble/template_config_partitions.py
+++ b/views_pipeline_core/templates/ensemble/template_config_partitions.py
@@ -39,11 +39,11 @@ def generate(steps: int = 36) -> dict:
     """
 
     def forecasting_train_range():
-        month_last = ViewsMonth.now().id - 2
+        month_last = ViewsMonth.now().id - 1
         return (121, month_last)
 
     def forecasting_test_range(steps):
-        month_last = ViewsMonth.now().id - 2
+        month_last = ViewsMonth.now().id - 1
         return (month_last + 1, month_last + 1 + steps)
 
     return {

--- a/views_pipeline_core/templates/model/template_config_partitions.py
+++ b/views_pipeline_core/templates/model/template_config_partitions.py
@@ -39,11 +39,11 @@ def generate(steps: int = 36) -> dict:
     """
 
     def forecasting_train_range():
-        month_last = ViewsMonth.now().id - 2
+        month_last = ViewsMonth.now().id - 1
         return (121, month_last)
 
     def forecasting_test_range(steps):
-        month_last = ViewsMonth.now().id - 2
+        month_last = ViewsMonth.now().id - 1
         return (month_last + 1, month_last + 1 + steps)
 
     return {


### PR DESCRIPTION
- Use the `override_timestamp` flag to override the end of history for forecasting run type.
- Improve the logic in `ViewsDataloader`.