### PR TITLE
fix sweep config using hyperparameter config

### DIFF
--- a/views_pipeline_core/managers/configuration/configuration.py
+++ b/views_pipeline_core/managers/configuration/configuration.py
@@ -503,6 +503,26 @@ class ConfigurationManager:
         
         return config
     
+    def get_combined_sweep_config(self) -> Dict:
+        """
+        Get merged configuration from all sources for sweep run.
+        """
+        config = {}
+        if self.partition_dict:
+            config.update(self.partition_dict)
+        if self.config_deployment:
+            config.update(self.config_deployment)
+        if self.config_meta:
+            if "targets" in self.config_meta:
+                if isinstance(self.config_meta["targets"], str):
+                    self.config_meta["targets"] = [self.config_meta["targets"]]
+            config.update(self.config_meta)
+        if self._runtime_config:
+            config.update(self._runtime_config)
+
+        return config
+        
+    
     def add_config(self, config: Dict) -> None:
         """
         Add runtime configuration values.
@@ -810,7 +830,7 @@ class ConfigurationManager:
 
         # Validate configuration
         try:
-            validate_config(self.get_combined_config())
+            validate_config(self.get_combined_sweep_config())
         except Exception as e:
             raise ConfigurationException(
                 f"Sweep configuration validation failed: {e}",

--- a/views_pipeline_core/managers/model/model.py
+++ b/views_pipeline_core/managers/model/model.py
@@ -1298,7 +1298,7 @@ class ModelManager:
     @property
     def configs(self) -> Dict:
         """Get combined configuration."""
-        return self._config_manager.get_combined_config()
+        return self._config_manager.get_combined_config() if not self._sweep else self._config_manager.get_combined_sweep_config()
     
     @configs.setter
     def configs(self, config: Dict) -> None:


### PR DESCRIPTION
Sweep will use parameters from `config_hyperparameters.py`, which should be avoided if parameters are in `config_hyperparameters.py` but not in `config_sweep.py`.