### PR TITLE
feat(C-51): add _fetch_data_from_datafactory() method

### DIFF
--- a/tests/test_modules/test_fetch_from_datafactory.py
+++ b/tests/test_modules/test_fetch_from_datafactory.py
@@ -1,0 +1,202 @@
+"""
+Tests for ViewsDataLoader._fetch_data_from_datafactory() — the datafactory
+fetch strategy added in PR 3.
+
+Pure additive. The method is not yet wired into get_data().
+"""
+
+import logging
+
+import pytest
+from unittest.mock import MagicMock, patch
+from pathlib import Path
+import pandas as pd
+import numpy as np
+
+from views_pipeline_core.modules.dataloaders import ViewsDataLoader
+from views_pipeline_core.data.model_path import ModelPathManager
+
+
+SAMPLE_DESCRIPTOR = {
+    "name": "test_model",
+    "source": "views-datafactory",
+    "zarr_url": "http://example.com/grid.zarr",
+    "region": "africa_me_legacy",
+    "loa": "priogrid_month",
+    "features": {
+        "ged_sb_best": "lr_sb_best",
+        "ged_ns_best": "lr_ns_best",
+        "ged_os_best": "lr_os_best",
+        "gaul0_code": "c_id",
+    },
+}
+
+
+@pytest.fixture
+def sample_factory_df():
+    """DataFrame as returned by load_dataset() — factory column names, priogrid index."""
+    month_ids = list(range(121, 125))
+    pg_ids = [100001, 100002, 100003]
+    index = pd.MultiIndex.from_product(
+        [month_ids, pg_ids], names=["month_id", "priogrid_gid"]
+    )
+    return pd.DataFrame(
+        {
+            "ged_sb_best": np.random.randn(len(index)),
+            "ged_ns_best": np.random.randn(len(index)),
+            "ged_os_best": np.random.randn(len(index)),
+            "gaul0_code": np.random.randint(1, 100, len(index)).astype(float),
+        },
+        index=index,
+    )
+
+
+@pytest.fixture
+def datafactory_loader():
+    mock_path = MagicMock(spec=ModelPathManager)
+    mock_path.model_name = "test_model"
+    mock_path.data_raw = Path("/tmp/test/data/raw")
+    mock_path.data_processed = Path("/tmp/test/data/processed")
+    mock_path.get_queryset.return_value = SAMPLE_DESCRIPTOR.copy()
+
+    loader = ViewsDataLoader(model_path=mock_path, steps=36)
+    loader.month_first = 121
+    loader.month_last = 444
+    loader.drift_config_dict = {}
+    return loader
+
+
+class TestFetchFromDatafactory:
+
+    @patch("views_pipeline_core.modules.dataloaders.dataloaders.ensure_float64", side_effect=lambda df: df)
+    def test_successful_fetch_renames_columns(
+        self, mock_f64, datafactory_loader, sample_factory_df
+    ):
+        """Columns renamed from factory names to VIEWSER names per descriptor."""
+        with patch.dict("sys.modules", {"datafactory_query": MagicMock()}):
+            import sys
+            sys.modules["datafactory_query"].load_dataset = MagicMock(return_value=sample_factory_df)
+
+            df, alerts = datafactory_loader._fetch_data_from_datafactory(self_test=False)
+
+            assert "lr_sb_best" in df.columns
+            assert "lr_ns_best" in df.columns
+            assert "ged_sb_best" not in df.columns
+            assert alerts is None
+
+    @patch("views_pipeline_core.modules.dataloaders.dataloaders.ensure_float64", side_effect=lambda df: df)
+    def test_row_col_derived_from_priogrid(
+        self, mock_f64, datafactory_loader, sample_factory_df
+    ):
+        """row and col columns derived from priogrid_gid for priogrid_month models."""
+        with patch.dict("sys.modules", {"datafactory_query": MagicMock()}):
+            import sys
+            sys.modules["datafactory_query"].load_dataset = MagicMock(return_value=sample_factory_df)
+
+            df, _ = datafactory_loader._fetch_data_from_datafactory(self_test=False)
+
+            assert "row" in df.columns
+            assert "col" in df.columns
+            assert (df["row"] > 0).all()
+            assert (df["col"] > 0).all()
+
+            # Verify formula for pgid=100001: row = (100000)//720 + 1 = 139, col = (100000)%720 + 1 = 641
+            first_row = df.loc[(121, 100001)]
+            assert first_row["row"] == (100001 - 1) // 720 + 1
+            assert first_row["col"] == (100001 - 1) % 720 + 1
+
+    @patch("views_pipeline_core.modules.dataloaders.dataloaders.ensure_float64", side_effect=lambda df: df)
+    def test_nan_filled(self, mock_f64, datafactory_loader):
+        """NaN values filled with 0.0."""
+        index = pd.MultiIndex.from_tuples(
+            [(121, 1000)], names=["month_id", "priogrid_gid"]
+        )
+        nan_df = pd.DataFrame({"ged_sb_best": [float("nan")]}, index=index)
+
+        datafactory_loader._model_path.get_queryset.return_value = {
+            **SAMPLE_DESCRIPTOR, "features": {"ged_sb_best": "lr_sb_best"}
+        }
+
+        with patch.dict("sys.modules", {"datafactory_query": MagicMock()}):
+            import sys
+            sys.modules["datafactory_query"].load_dataset = MagicMock(return_value=nan_df)
+
+            df, _ = datafactory_loader._fetch_data_from_datafactory(self_test=False)
+            assert not df.isna().any().any()
+
+    def test_ensure_float64_called(self, datafactory_loader, sample_factory_df):
+        """ensure_float64() is called on the result."""
+        with patch.dict("sys.modules", {"datafactory_query": MagicMock()}):
+            import sys
+            sys.modules["datafactory_query"].load_dataset = MagicMock(return_value=sample_factory_df)
+
+            with patch("views_pipeline_core.modules.dataloaders.dataloaders.ensure_float64") as mock_f64:
+                mock_f64.return_value = sample_factory_df
+                datafactory_loader._fetch_data_from_datafactory(self_test=False)
+                mock_f64.assert_called_once()
+
+    @patch("views_pipeline_core.modules.dataloaders.dataloaders.ensure_float64", side_effect=lambda df: df)
+    def test_alerts_always_none(self, mock_f64, datafactory_loader, sample_factory_df):
+        """Datafactory fetch always returns alerts=None (C-52)."""
+        with patch.dict("sys.modules", {"datafactory_query": MagicMock()}):
+            import sys
+            sys.modules["datafactory_query"].load_dataset = MagicMock(return_value=sample_factory_df)
+
+            _, alerts = datafactory_loader._fetch_data_from_datafactory(self_test=False)
+            assert alerts is None
+
+            _, alerts = datafactory_loader._fetch_data_from_datafactory(self_test=True)
+            assert alerts is None
+
+    @patch("views_pipeline_core.modules.dataloaders.dataloaders.ensure_float64", side_effect=lambda df: df)
+    def test_drift_warning_on_self_test(
+        self, mock_f64, datafactory_loader, sample_factory_df, caplog
+    ):
+        """Warning logged when drift self-test requested for datafactory source."""
+        with patch.dict("sys.modules", {"datafactory_query": MagicMock()}):
+            import sys
+            sys.modules["datafactory_query"].load_dataset = MagicMock(return_value=sample_factory_df)
+
+            with caplog.at_level(logging.WARNING):
+                datafactory_loader._fetch_data_from_datafactory(self_test=True)
+
+            assert "Drift detection" in caplog.text
+            assert "C-52" in caplog.text
+
+    def test_fetch_failure_raises_runtime_error(self, datafactory_loader):
+        """load_dataset() failure wrapped in RuntimeError."""
+        with patch.dict("sys.modules", {"datafactory_query": MagicMock()}):
+            import sys
+            sys.modules["datafactory_query"].load_dataset = MagicMock(
+                side_effect=ConnectionError("timeout")
+            )
+
+            with pytest.raises(RuntimeError, match="Error fetching data from datafactory"):
+                datafactory_loader._fetch_data_from_datafactory(self_test=False)
+
+    def test_non_dict_descriptor_raises(self, datafactory_loader):
+        """get_queryset() returning non-dict raises RuntimeError."""
+        datafactory_loader._model_path.get_queryset.return_value = "not a dict"
+
+        with pytest.raises(RuntimeError, match="Expected dict descriptor"):
+            datafactory_loader._fetch_data_from_datafactory(self_test=False)
+
+    @patch("views_pipeline_core.modules.dataloaders.dataloaders.ensure_float64", side_effect=lambda df: df)
+    def test_country_month_no_row_col(self, mock_f64, datafactory_loader):
+        """country_month models don't get row/col columns."""
+        index = pd.MultiIndex.from_tuples(
+            [(121, 1)], names=["month_id", "country_id"]
+        )
+        cm_df = pd.DataFrame({"ged_sb_best": [1.0]}, index=index)
+
+        datafactory_loader._model_path.get_queryset.return_value = {
+            **SAMPLE_DESCRIPTOR, "loa": "country_month"
+        }
+
+        with patch.dict("sys.modules", {"datafactory_query": MagicMock()}):
+            import sys
+            sys.modules["datafactory_query"].load_dataset = MagicMock(return_value=cm_df)
+
+            df, _ = datafactory_loader._fetch_data_from_datafactory(self_test=False)
+            assert "row" not in df.columns
+            assert "col" not in df.columns

--- a/tests/test_modules/test_fetch_from_datafactory.py
+++ b/tests/test_modules/test_fetch_from_datafactory.py
@@ -14,6 +14,7 @@ import pandas as pd
 import numpy as np
 
 from views_pipeline_core.modules.dataloaders import ViewsDataLoader
+from views_pipeline_core.modules.dataloaders.dataloaders import _PRIOGRID_NCOL
 from views_pipeline_core.data.model_path import ModelPathManager
 
 
@@ -67,47 +68,50 @@ def datafactory_loader():
     return loader
 
 
+@pytest.fixture
+def mock_datafactory_module():
+    """Patch sys.modules so `from datafactory_query import load_dataset` resolves."""
+    mock_module = MagicMock()
+    with patch.dict("sys.modules", {"datafactory_query": mock_module}):
+        yield mock_module
+
+
 class TestFetchFromDatafactory:
 
     @patch("views_pipeline_core.modules.dataloaders.dataloaders.ensure_float64", side_effect=lambda df: df)
     def test_successful_fetch_renames_columns(
-        self, mock_f64, datafactory_loader, sample_factory_df
+        self, mock_f64, datafactory_loader, sample_factory_df, mock_datafactory_module
     ):
         """Columns renamed from factory names to VIEWSER names per descriptor."""
-        with patch.dict("sys.modules", {"datafactory_query": MagicMock()}):
-            import sys
-            sys.modules["datafactory_query"].load_dataset = MagicMock(return_value=sample_factory_df)
+        mock_datafactory_module.load_dataset = MagicMock(return_value=sample_factory_df)
 
-            df, alerts = datafactory_loader._fetch_data_from_datafactory(self_test=False)
+        df, alerts = datafactory_loader._fetch_data_from_datafactory(self_test=False)
 
-            assert "lr_sb_best" in df.columns
-            assert "lr_ns_best" in df.columns
-            assert "ged_sb_best" not in df.columns
-            assert alerts is None
+        assert "lr_sb_best" in df.columns
+        assert "lr_ns_best" in df.columns
+        assert "ged_sb_best" not in df.columns
+        assert alerts is None
 
     @patch("views_pipeline_core.modules.dataloaders.dataloaders.ensure_float64", side_effect=lambda df: df)
     def test_row_col_derived_from_priogrid(
-        self, mock_f64, datafactory_loader, sample_factory_df
+        self, mock_f64, datafactory_loader, sample_factory_df, mock_datafactory_module
     ):
         """row and col columns derived from priogrid_gid for priogrid_month models."""
-        with patch.dict("sys.modules", {"datafactory_query": MagicMock()}):
-            import sys
-            sys.modules["datafactory_query"].load_dataset = MagicMock(return_value=sample_factory_df)
+        mock_datafactory_module.load_dataset = MagicMock(return_value=sample_factory_df)
 
-            df, _ = datafactory_loader._fetch_data_from_datafactory(self_test=False)
+        df, _ = datafactory_loader._fetch_data_from_datafactory(self_test=False)
 
-            assert "row" in df.columns
-            assert "col" in df.columns
-            assert (df["row"] > 0).all()
-            assert (df["col"] > 0).all()
+        assert "row" in df.columns
+        assert "col" in df.columns
+        assert (df["row"] > 0).all()
+        assert (df["col"] > 0).all()
 
-            # Verify formula for pgid=100001: row = (100000)//720 + 1 = 139, col = (100000)%720 + 1 = 641
-            first_row = df.loc[(121, 100001)]
-            assert first_row["row"] == (100001 - 1) // 720 + 1
-            assert first_row["col"] == (100001 - 1) % 720 + 1
+        first_row = df.loc[(121, 100001)]
+        assert first_row["row"] == (100001 - 1) // _PRIOGRID_NCOL + 1
+        assert first_row["col"] == (100001 - 1) % _PRIOGRID_NCOL + 1
 
     @patch("views_pipeline_core.modules.dataloaders.dataloaders.ensure_float64", side_effect=lambda df: df)
-    def test_nan_filled(self, mock_f64, datafactory_loader):
+    def test_nan_filled(self, mock_f64, datafactory_loader, mock_datafactory_module):
         """NaN values filled with 0.0."""
         index = pd.MultiIndex.from_tuples(
             [(121, 1000)], names=["month_id", "priogrid_gid"]
@@ -117,63 +121,58 @@ class TestFetchFromDatafactory:
         datafactory_loader._model_path.get_queryset.return_value = {
             **SAMPLE_DESCRIPTOR, "features": {"ged_sb_best": "lr_sb_best"}
         }
+        mock_datafactory_module.load_dataset = MagicMock(return_value=nan_df)
 
-        with patch.dict("sys.modules", {"datafactory_query": MagicMock()}):
-            import sys
-            sys.modules["datafactory_query"].load_dataset = MagicMock(return_value=nan_df)
+        df, _ = datafactory_loader._fetch_data_from_datafactory(self_test=False)
+        assert not df.isna().any().any()
 
-            df, _ = datafactory_loader._fetch_data_from_datafactory(self_test=False)
-            assert not df.isna().any().any()
-
-    def test_ensure_float64_called(self, datafactory_loader, sample_factory_df):
+    def test_ensure_float64_called(
+        self, datafactory_loader, sample_factory_df, mock_datafactory_module
+    ):
         """ensure_float64() is called on the result."""
-        with patch.dict("sys.modules", {"datafactory_query": MagicMock()}):
-            import sys
-            sys.modules["datafactory_query"].load_dataset = MagicMock(return_value=sample_factory_df)
+        mock_datafactory_module.load_dataset = MagicMock(return_value=sample_factory_df)
 
-            with patch("views_pipeline_core.modules.dataloaders.dataloaders.ensure_float64") as mock_f64:
-                mock_f64.return_value = sample_factory_df
-                datafactory_loader._fetch_data_from_datafactory(self_test=False)
-                mock_f64.assert_called_once()
+        with patch("views_pipeline_core.modules.dataloaders.dataloaders.ensure_float64") as mock_f64:
+            mock_f64.return_value = sample_factory_df
+            datafactory_loader._fetch_data_from_datafactory(self_test=False)
+            mock_f64.assert_called_once()
 
     @patch("views_pipeline_core.modules.dataloaders.dataloaders.ensure_float64", side_effect=lambda df: df)
-    def test_alerts_always_none(self, mock_f64, datafactory_loader, sample_factory_df):
+    def test_alerts_always_none(
+        self, mock_f64, datafactory_loader, sample_factory_df, mock_datafactory_module
+    ):
         """Datafactory fetch always returns alerts=None (C-52)."""
-        with patch.dict("sys.modules", {"datafactory_query": MagicMock()}):
-            import sys
-            sys.modules["datafactory_query"].load_dataset = MagicMock(return_value=sample_factory_df)
+        mock_datafactory_module.load_dataset = MagicMock(return_value=sample_factory_df)
 
-            _, alerts = datafactory_loader._fetch_data_from_datafactory(self_test=False)
-            assert alerts is None
+        _, alerts = datafactory_loader._fetch_data_from_datafactory(self_test=False)
+        assert alerts is None
 
-            _, alerts = datafactory_loader._fetch_data_from_datafactory(self_test=True)
-            assert alerts is None
+        _, alerts = datafactory_loader._fetch_data_from_datafactory(self_test=True)
+        assert alerts is None
 
     @patch("views_pipeline_core.modules.dataloaders.dataloaders.ensure_float64", side_effect=lambda df: df)
     def test_drift_warning_on_self_test(
-        self, mock_f64, datafactory_loader, sample_factory_df, caplog
+        self, mock_f64, datafactory_loader, sample_factory_df, mock_datafactory_module, caplog
     ):
         """Warning logged when drift self-test requested for datafactory source."""
-        with patch.dict("sys.modules", {"datafactory_query": MagicMock()}):
-            import sys
-            sys.modules["datafactory_query"].load_dataset = MagicMock(return_value=sample_factory_df)
+        mock_datafactory_module.load_dataset = MagicMock(return_value=sample_factory_df)
 
-            with caplog.at_level(logging.WARNING):
-                datafactory_loader._fetch_data_from_datafactory(self_test=True)
+        with caplog.at_level(logging.WARNING):
+            datafactory_loader._fetch_data_from_datafactory(self_test=True)
 
-            assert "Drift detection" in caplog.text
-            assert "C-52" in caplog.text
+        assert "Drift detection" in caplog.text
+        assert "C-52" in caplog.text
 
-    def test_fetch_failure_raises_runtime_error(self, datafactory_loader):
+    def test_fetch_failure_raises_runtime_error(
+        self, datafactory_loader, mock_datafactory_module
+    ):
         """load_dataset() failure wrapped in RuntimeError."""
-        with patch.dict("sys.modules", {"datafactory_query": MagicMock()}):
-            import sys
-            sys.modules["datafactory_query"].load_dataset = MagicMock(
-                side_effect=ConnectionError("timeout")
-            )
+        mock_datafactory_module.load_dataset = MagicMock(
+            side_effect=ConnectionError("timeout")
+        )
 
-            with pytest.raises(RuntimeError, match="Error fetching data from datafactory"):
-                datafactory_loader._fetch_data_from_datafactory(self_test=False)
+        with pytest.raises(RuntimeError, match="Error fetching data from datafactory"):
+            datafactory_loader._fetch_data_from_datafactory(self_test=False)
 
     def test_non_dict_descriptor_raises(self, datafactory_loader):
         """get_queryset() returning non-dict raises RuntimeError."""
@@ -192,7 +191,9 @@ class TestFetchFromDatafactory:
             datafactory_loader._fetch_data_from_datafactory(self_test=False)
 
     @patch("views_pipeline_core.modules.dataloaders.dataloaders.ensure_float64", side_effect=lambda df: df)
-    def test_country_month_no_row_col(self, mock_f64, datafactory_loader):
+    def test_country_month_no_row_col(
+        self, mock_f64, datafactory_loader, mock_datafactory_module
+    ):
         """country_month models don't get row/col columns."""
         index = pd.MultiIndex.from_tuples(
             [(121, 1)], names=["month_id", "country_id"]
@@ -202,11 +203,8 @@ class TestFetchFromDatafactory:
         datafactory_loader._model_path.get_queryset.return_value = {
             **SAMPLE_DESCRIPTOR, "loa": "country_month"
         }
+        mock_datafactory_module.load_dataset = MagicMock(return_value=cm_df)
 
-        with patch.dict("sys.modules", {"datafactory_query": MagicMock()}):
-            import sys
-            sys.modules["datafactory_query"].load_dataset = MagicMock(return_value=cm_df)
-
-            df, _ = datafactory_loader._fetch_data_from_datafactory(self_test=False)
-            assert "row" not in df.columns
-            assert "col" not in df.columns
+        df, _ = datafactory_loader._fetch_data_from_datafactory(self_test=False)
+        assert "row" not in df.columns
+        assert "col" not in df.columns

--- a/tests/test_modules/test_fetch_from_datafactory.py
+++ b/tests/test_modules/test_fetch_from_datafactory.py
@@ -35,6 +35,7 @@ SAMPLE_DESCRIPTOR = {
 @pytest.fixture
 def sample_factory_df():
     """DataFrame as returned by load_dataset() — factory column names, priogrid index."""
+    rng = np.random.default_rng(42)
     month_ids = list(range(121, 125))
     pg_ids = [100001, 100002, 100003]
     index = pd.MultiIndex.from_product(
@@ -42,10 +43,10 @@ def sample_factory_df():
     )
     return pd.DataFrame(
         {
-            "ged_sb_best": np.random.randn(len(index)),
-            "ged_ns_best": np.random.randn(len(index)),
-            "ged_os_best": np.random.randn(len(index)),
-            "gaul0_code": np.random.randint(1, 100, len(index)).astype(float),
+            "ged_sb_best": rng.standard_normal(len(index)),
+            "ged_ns_best": rng.standard_normal(len(index)),
+            "ged_os_best": rng.standard_normal(len(index)),
+            "gaul0_code": rng.integers(1, 100, len(index)).astype(float),
         },
         index=index,
     )
@@ -179,6 +180,15 @@ class TestFetchFromDatafactory:
         datafactory_loader._model_path.get_queryset.return_value = "not a dict"
 
         with pytest.raises(RuntimeError, match="Expected dict descriptor"):
+            datafactory_loader._fetch_data_from_datafactory(self_test=False)
+
+    def test_missing_required_keys_raises(self, datafactory_loader):
+        """Descriptor missing required keys raises RuntimeError."""
+        datafactory_loader._model_path.get_queryset.return_value = {
+            "name": "test", "source": "views-datafactory",
+        }
+
+        with pytest.raises(RuntimeError, match="missing required keys"):
             datafactory_loader._fetch_data_from_datafactory(self_test=False)
 
     @patch("views_pipeline_core.modules.dataloaders.dataloaders.ensure_float64", side_effect=lambda df: df)

--- a/views_pipeline_core/modules/dataloaders/dataloaders.py
+++ b/views_pipeline_core/modules/dataloaders/dataloaders.py
@@ -24,6 +24,7 @@ import argparse
 
 logger = logging.getLogger(__name__)
 
+_PRIOGRID_NCOL = 720
 
 # Ingester dependent imports. Breaks tests on github because no certs
 def _get_splag_country(*args, **kwargs):
@@ -1100,8 +1101,10 @@ class ViewsDataLoader:
             f"(with 'source': 'views-datafactory')."
         )
 
-    def _fetch_data_from_datafactory(self, self_test: bool) -> tuple[pd.DataFrame, list]:
-        """Fetch data from views-datafactory using the dict descriptor from get_queryset().
+    def _fetch_data_from_datafactory(
+        self, self_test: bool, descriptor: Optional[dict] = None,
+    ) -> tuple[pd.DataFrame, None]:
+        """Fetch data from views-datafactory using a dict descriptor.
 
         Counterpart to _fetch_data_from_viewser(). Lazy-imports datafactory_query,
         renames columns to VIEWSER conventions, derives row/col for priogrid models,
@@ -1110,6 +1113,7 @@ class ViewsDataLoader:
         Args:
             self_test: Whether drift detection self-testing was requested.
                 Logged as a warning since datafactory has no drift detection.
+            descriptor: Pre-fetched dict descriptor. If None, calls get_queryset().
 
         Returns:
             Tuple of (dataframe, None). Alerts are always None.
@@ -1118,7 +1122,8 @@ class ViewsDataLoader:
             RuntimeError: If descriptor is invalid or load_dataset() fails.
             ImportError: If datafactory_query is not installed.
         """
-        descriptor = self._model_path.get_queryset()
+        if descriptor is None:
+            descriptor = self._model_path.get_queryset()
 
         if descriptor is None or not isinstance(descriptor, dict):
             raise RuntimeError(
@@ -1164,14 +1169,13 @@ class ViewsDataLoader:
         if feature_rename:
             df = df.rename(columns=feature_rename)
 
-        NCOL = 720
         loa = descriptor.get("loa", "")
         if loa == "priogrid_month" and "priogrid_gid" in df.index.names:
             pgids = df.index.get_level_values("priogrid_gid")
             if "row" not in df.columns:
-                df["row"] = ((pgids - 1) // NCOL + 1).astype(float)
+                df["row"] = ((pgids - 1) // _PRIOGRID_NCOL + 1).astype(float)
             if "col" not in df.columns:
-                df["col"] = ((pgids - 1) % NCOL + 1).astype(float)
+                df["col"] = ((pgids - 1) % _PRIOGRID_NCOL + 1).astype(float)
 
         df = df.fillna(0.0)
         df = df.sort_index()

--- a/views_pipeline_core/modules/dataloaders/dataloaders.py
+++ b/views_pipeline_core/modules/dataloaders/dataloaders.py
@@ -1131,6 +1131,14 @@ class ViewsDataLoader:
                 f"got {type(descriptor).__name__}"
             )
 
+        _required_keys = {"region", "features", "zarr_url"}
+        missing = _required_keys - descriptor.keys()
+        if missing:
+            raise RuntimeError(
+                f"Datafactory descriptor for {self._model_name} is missing "
+                f"required keys: {sorted(missing)}"
+            )
+
         logger.info(
             f"Beginning data fetch from views-datafactory for {self._model_name} "
             f"(zarr_url={descriptor.get('zarr_url', '?')}, "

--- a/views_pipeline_core/modules/dataloaders/dataloaders.py
+++ b/views_pipeline_core/modules/dataloaders/dataloaders.py
@@ -25,6 +25,7 @@ import argparse
 logger = logging.getLogger(__name__)
 
 _PRIOGRID_NCOL = 720
+_DATAFACTORY_REQUIRED_KEYS = {"region", "features", "zarr_url"}
 
 # Ingester dependent imports. Breaks tests on github because no certs
 def _get_splag_country(*args, **kwargs):
@@ -1131,8 +1132,7 @@ class ViewsDataLoader:
                 f"got {type(descriptor).__name__}"
             )
 
-        _required_keys = {"region", "features", "zarr_url"}
-        missing = _required_keys - descriptor.keys()
+        missing = _DATAFACTORY_REQUIRED_KEYS - descriptor.keys()
         if missing:
             raise RuntimeError(
                 f"Datafactory descriptor for {self._model_name} is missing "

--- a/views_pipeline_core/modules/dataloaders/dataloaders.py
+++ b/views_pipeline_core/modules/dataloaders/dataloaders.py
@@ -1100,6 +1100,97 @@ class ViewsDataLoader:
             f"(with 'source': 'views-datafactory')."
         )
 
+    def _fetch_data_from_datafactory(self, self_test: bool) -> tuple[pd.DataFrame, list]:
+        """Fetch data from views-datafactory using the dict descriptor from get_queryset().
+
+        Counterpart to _fetch_data_from_viewser(). Lazy-imports datafactory_query,
+        renames columns to VIEWSER conventions, derives row/col for priogrid models,
+        fills NaN, and casts to float64. Does NOT support drift detection (C-52).
+
+        Args:
+            self_test: Whether drift detection self-testing was requested.
+                Logged as a warning since datafactory has no drift detection.
+
+        Returns:
+            Tuple of (dataframe, None). Alerts are always None.
+
+        Raises:
+            RuntimeError: If descriptor is invalid or load_dataset() fails.
+            ImportError: If datafactory_query is not installed.
+        """
+        descriptor = self._model_path.get_queryset()
+
+        if descriptor is None or not isinstance(descriptor, dict):
+            raise RuntimeError(
+                f"Expected dict descriptor for datafactory model {self._model_name}, "
+                f"got {type(descriptor).__name__}"
+            )
+
+        logger.info(
+            f"Beginning data fetch from views-datafactory for {self._model_name} "
+            f"(zarr_url={descriptor.get('zarr_url', '?')}, "
+            f"region={descriptor.get('region', '?')}, "
+            f"months={self.month_first}-{self.month_last})"
+        )
+
+        try:
+            from datafactory_query import load_dataset
+        except ImportError as e:
+            raise ImportError(
+                f"datafactory_query is required for model {self._model_name} "
+                f"(source='views-datafactory') but is not installed. "
+                f"Install via: pip install 'views-datafactory @ "
+                f"git+https://github.com/views-platform/views-datafactory.git@development'"
+            ) from e
+
+        try:
+            df = load_dataset(
+                region=descriptor["region"],
+                start=self.month_first,
+                end=self.month_last,
+                features=list(descriptor["features"].keys()),
+                output_format="dataframe",
+                data_dir=descriptor["zarr_url"],
+            )
+        except Exception as e:
+            logger.error(
+                f"Error fetching data from datafactory: {e}", exc_info=True
+            )
+            raise RuntimeError(
+                f"Error fetching data from datafactory for {self._model_name}: {e}"
+            ) from e
+
+        feature_rename = descriptor.get("features", {})
+        if feature_rename:
+            df = df.rename(columns=feature_rename)
+
+        NCOL = 720
+        loa = descriptor.get("loa", "")
+        if loa == "priogrid_month" and "priogrid_gid" in df.index.names:
+            pgids = df.index.get_level_values("priogrid_gid")
+            if "row" not in df.columns:
+                df["row"] = ((pgids - 1) // NCOL + 1).astype(float)
+            if "col" not in df.columns:
+                df["col"] = ((pgids - 1) % NCOL + 1).astype(float)
+
+        df = df.fillna(0.0)
+        df = df.sort_index()
+        df = ensure_float64(df)
+
+        if self_test:
+            logger.warning(
+                f"Drift detection self-test requested for {self._model_name} "
+                f"but is not available for views-datafactory sources. "
+                f"Returning alerts=None. See risk register C-52."
+            )
+
+        logger.info(
+            f"Datafactory fetch complete for {self._model_name}: "
+            f"{len(df)} rows, {len(df.columns)} columns"
+        )
+
+        return df, None
+
     def _get_month_range(self) -> tuple[int, int]:
         """
         Determine month range based on partition type.


### PR DESCRIPTION
## Summary

- Adds `_fetch_data_from_datafactory()` to `ViewsDataLoader` — the datafactory counterpart to `_fetch_data_from_viewser()`
- Lazy-imports `datafactory_query` (never loaded for viewser models)
- Renames columns from factory names to VIEWSER names per descriptor `features` mapping
- Derives `row`/`col` from `priogrid_gid` for `priogrid_month` models (NCOL=720), skips for `country_month`
- Fills NaN with 0.0, sorts index, casts to float64 via `ensure_float64()`
- Returns `alerts=None` — drift detection not available for datafactory (C-52 accepted, logged warning on `self_test=True`)
- 9 tests covering: column renaming, PRIO-GRID derivation with formula verification, NaN fill, ensure_float64, alerts=None, drift warning, error wrapping, non-dict descriptor, country_month exclusion

**Not yet wired into `get_data()`** — dispatch lands in PR4.

PR 3 of 5 in the viewser→views-datafactory migration ([roadmap](reports/adress_non-viewser_data_sources/ROADMAP.md)).

## Test plan

- [x] All 9 new tests pass (`pytest tests/test_modules/test_fetch_from_datafactory.py -v`)
- [x] All 6 PR2 source detection tests still pass
- [x] All 24 PR1 characterization tests still pass
- [x] Full suite: 1132 passed (2 pre-existing ordering-dependent failures, 6 pre-existing fixture errors in `reports/investigations/`)
- [x] `ruff check` clean on all changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)