### PR TITLE
feat(C-51): wire dual-source dispatch into get_data()

### DIFF
--- a/tests/test_modules/test_dataloader_characterization.py
+++ b/tests/test_modules/test_dataloader_characterization.py
@@ -251,16 +251,15 @@ class TestEnsureFloat64Guarantee:
 # Test 5: Dict descriptor crash — characterizes bug C-51
 # ============================================================================
 
-class TestDictDescriptorCrash:
-    """When get_queryset() returns a dict, _fetch_data_from_viewser() crashes
-    with AttributeError because dict has no .publish() method.
-
-    This test characterizes bug C-51. Expected to fail after PR 4 (dispatch fix).
+class TestDictDescriptorDispatch:
+    """After PR 4, dict descriptors route to _fetch_data_from_datafactory
+    instead of crashing. This replaced the C-51 characterization test.
     """
 
-    def test_dict_descriptor_crashes(self, sample_df):
-        """dict.publish() raises AttributeError, caught by generic except and
-        re-raised as RuntimeError. The root cause is AttributeError."""
+    @patch("views_pipeline_core.modules.dataloaders.dataloaders.save_dataframe")
+    @patch("views_pipeline_core.modules.dataloaders.dataloaders.create_data_fetch_log_file")
+    def test_dict_descriptor_dispatches_to_datafactory(self, mock_log, mock_save, sample_df):
+        """Dict descriptor with source='views-datafactory' dispatches to datafactory fetch."""
         mock_path = MagicMock(spec=ModelPathManager)
         mock_path.model_name = "bright_starship"
         mock_path.data_raw = Path("/tmp/test/data/raw")
@@ -281,10 +280,13 @@ class TestDictDescriptorCrash:
         dl.month_first = 121
         dl.month_last = 444
 
-        with pytest.raises(RuntimeError, match="has no attribute 'publish'") as exc_info:
-            dl._fetch_data_from_viewser(self_test=False)
-
-        assert isinstance(exc_info.value.__cause__, AttributeError)
+        with patch.object(dl, "_fetch_data_from_datafactory", return_value=(sample_df, None)) as mock_factory:
+            df, alerts = dl.get_data(
+                self_test=False, partition="calibration",
+                use_saved=False, validate=False,
+            )
+            mock_factory.assert_called_once()
+            assert alerts is None
 
 
 # ============================================================================
@@ -396,15 +398,15 @@ class TestCoreDataSnifferGating:
 # ============================================================================
 
 class TestPostEvalLogReadAssumption:
-    """handle_single_log_creation() unconditionally reads
-    {run_type}_data_fetch_log.txt via read_log_file(). When the file is missing
-    (cached data path), read_log_file raises FileNotFoundError.
+    """After PR 4, handle_single_log_creation() gracefully handles missing
+    fetch logs (data loaded from cache or via non-viewser source).
 
-    This test characterizes the coupling between get_data() (writes the log on
-    fresh fetch only) and handle_single_log_creation() (reads it unconditionally).
+    Previously this crashed with FileNotFoundError (characterization test).
+    Now it proceeds with data_fetch_timestamp=None and logs a warning.
     """
 
-    def test_missing_fetch_log_raises_file_not_found(self, tmp_path):
+    def test_missing_fetch_log_proceeds_with_warning(self, tmp_path, caplog):
+        import logging
         from views_pipeline_core.files.utils import handle_single_log_creation
 
         gen_dir = tmp_path / "generated"
@@ -421,8 +423,10 @@ class TestPostEvalLogReadAssumption:
             "deployment_status": "shadow",
         }
 
-        with pytest.raises(FileNotFoundError):
+        with caplog.at_level(logging.WARNING):
             handle_single_log_creation(mock_path, config, train=False)
+
+        assert "Data fetch log not found" in caplog.text
 
     def test_existing_fetch_log_does_not_raise(self, tmp_path):
         from views_pipeline_core.files.utils import handle_single_log_creation
@@ -456,8 +460,8 @@ class TestPostEvalLogReadAssumption:
 # ============================================================================
 
 class TestGetRawDataFilePathsFilter:
-    """_get_raw_data_file_paths() only finds files named *_viewser_df*.
-    After PR 4, it must also find *_datafactory_df* files."""
+    """_get_raw_data_file_paths() finds both *_viewser_df* and *_datafactory_df* files.
+    Updated in PR 4 to support dual-source dispatch."""
 
     @staticmethod
     def _call_get_raw(tmp_path, run_type):
@@ -473,12 +477,13 @@ class TestGetRawDataFilePathsFilter:
         assert len(paths) == 1
         assert paths[0].name == "calibration_viewser_df.parquet"
 
-    def test_does_not_find_datafactory_df_file(self, tmp_path):
-        """Currently, _datafactory_df files are invisible. PR 4 will fix this."""
+    def test_finds_datafactory_df_file(self, tmp_path):
+        """After PR 4, _datafactory_df files are visible."""
         (tmp_path / "calibration_datafactory_df.parquet").touch()
 
         paths = self._call_get_raw(tmp_path, "calibration")
-        assert len(paths) == 0
+        assert len(paths) == 1
+        assert paths[0].name == "calibration_datafactory_df.parquet"
 
     def test_ignores_unrelated_files(self, tmp_path):
         (tmp_path / "calibration_viewser_df.parquet").touch()

--- a/tests/test_modules/test_ensemble_check.py
+++ b/tests/test_modules/test_ensemble_check.py
@@ -561,23 +561,29 @@ class TestValidateEnsembleRawDataAlignment:
 
             assert validate_ensemble_raw_data_alignment(["model_a"], "calibration") is True
 
-    def test_models_with_different_file_sizes_warn(self):
+    def test_models_with_different_file_sizes_warn(self, tmp_path):
         """Models with different raw data file sizes should return False."""
+        dir_a = tmp_path / "model_a"
+        dir_a.mkdir()
+        file_a = dir_a / "calibration_viewser_df.parquet"
+        file_a.write_bytes(b"x" * 1000)
+
+        dir_b = tmp_path / "model_b"
+        dir_b.mkdir()
+        file_b = dir_b / "calibration_viewser_df.parquet"
+        file_b.write_bytes(b"x" * 2000)
+
         with patch(
             "views_pipeline_core.data.model_path.ModelPathManager"
         ) as MockMPM:
             mock_a = Mock()
-            mock_a.data_raw = Path("/tmp/test_a/data/raw")
+            mock_a._get_raw_data_file_paths.return_value = [file_a]
             mock_b = Mock()
-            mock_b.data_raw = Path("/tmp/test_b/data/raw")
+            mock_b._get_raw_data_file_paths.return_value = [file_b]
             MockMPM.side_effect = [mock_a, mock_b]
 
-            with patch("pathlib.Path.exists", return_value=True):
-                with patch("pathlib.Path.stat") as mock_stat:
-                    # Different sizes = different data
-                    mock_stat.side_effect = [Mock(st_size=1000), Mock(st_size=2000)]
-                    result = validate_ensemble_raw_data_alignment(
-                        ["model_a", "model_b"], "calibration"
-                    )
+            result = validate_ensemble_raw_data_alignment(
+                ["model_a", "model_b"], "calibration"
+            )
 
-            assert result is False
+        assert result is False

--- a/tests/test_modules/test_get_data_dispatch.py
+++ b/tests/test_modules/test_get_data_dispatch.py
@@ -1,0 +1,207 @@
+"""
+Tests for get_data() dispatch logic — PR 4.
+
+Verifies that get_data() detects the data source, constructs source-aware
+cache filenames, and dispatches to the correct fetch method.
+"""
+
+import logging
+
+import pytest
+from unittest.mock import MagicMock, patch
+import pandas as pd
+import numpy as np
+
+from views_pipeline_core.modules.dataloaders import ViewsDataLoader
+from views_pipeline_core.data.model_path import ModelPathManager
+from views_pipeline_core.files.utils import handle_single_log_creation
+
+
+@pytest.fixture
+def sample_df():
+    rng = np.random.default_rng(99)
+    index = pd.MultiIndex.from_product(
+        [range(121, 125), [100001, 100002]], names=["month_id", "priogrid_gid"]
+    )
+    return pd.DataFrame(
+        {"feature_a": rng.standard_normal(len(index))},
+        index=index,
+    )
+
+
+@pytest.fixture
+def viewser_loader(tmp_path):
+    mock_path = MagicMock(spec=ModelPathManager)
+    mock_path.model_name = "purple_alien"
+    mock_path.data_raw = tmp_path
+    mock_path.data_processed = tmp_path
+    mock_qs = MagicMock()
+    mock_qs.publish = MagicMock()
+    mock_path.get_queryset.return_value = mock_qs
+
+    loader = ViewsDataLoader(model_path=mock_path, steps=36)
+    loader.partition = "calibration"
+    loader.partition_dict = {"train": (121, 396), "test": (397, 444)}
+    loader.drift_config_dict = {"k": "v"}
+    loader.month_first = 121
+    loader.month_last = 444
+    return loader
+
+
+@pytest.fixture
+def datafactory_loader(tmp_path):
+    mock_path = MagicMock(spec=ModelPathManager)
+    mock_path.model_name = "bright_starship"
+    mock_path.data_raw = tmp_path
+    mock_path.data_processed = tmp_path
+    mock_path.get_queryset.return_value = {
+        "name": "bright_starship",
+        "source": "views-datafactory",
+        "zarr_url": "http://example.com/grid.zarr",
+        "region": "africa_me_legacy",
+        "loa": "priogrid_month",
+        "features": {"ged_sb_best": "lr_sb_best"},
+    }
+
+    loader = ViewsDataLoader(model_path=mock_path, steps=36)
+    loader.partition = "calibration"
+    loader.partition_dict = {"train": (121, 396), "test": (397, 444)}
+    loader.drift_config_dict = {"k": "v"}
+    loader.month_first = 121
+    loader.month_last = 444
+    return loader
+
+
+class TestDispatchRouting:
+
+    @patch("views_pipeline_core.modules.dataloaders.dataloaders.save_dataframe")
+    @patch("views_pipeline_core.modules.dataloaders.dataloaders.create_data_fetch_log_file")
+    def test_viewser_model_uses_viewser_fetch(
+        self, mock_log, mock_save, viewser_loader, sample_df
+    ):
+        """Viewser Queryset from get_queryset() dispatches to _fetch_data_from_viewser."""
+        with patch.object(viewser_loader, "_fetch_data_from_viewser", return_value=(sample_df, [])) as mock_viewser:
+            with patch.object(viewser_loader, "_fetch_data_from_datafactory") as mock_factory:
+                df, alerts = viewser_loader.get_data(
+                    self_test=False, partition="calibration",
+                    use_saved=False, validate=False,
+                )
+                mock_viewser.assert_called_once()
+                mock_factory.assert_not_called()
+
+    @patch("views_pipeline_core.modules.dataloaders.dataloaders.save_dataframe")
+    @patch("views_pipeline_core.modules.dataloaders.dataloaders.create_data_fetch_log_file")
+    def test_datafactory_model_uses_datafactory_fetch(
+        self, mock_log, mock_save, datafactory_loader, sample_df
+    ):
+        """Dict descriptor with source='views-datafactory' dispatches to _fetch_data_from_datafactory."""
+        with patch.object(datafactory_loader, "_fetch_data_from_datafactory", return_value=(sample_df, None)) as mock_factory:
+            with patch.object(datafactory_loader, "_fetch_data_from_viewser") as mock_viewser:
+                df, alerts = datafactory_loader.get_data(
+                    self_test=False, partition="calibration",
+                    use_saved=False, validate=False,
+                )
+                mock_factory.assert_called_once()
+                mock_viewser.assert_not_called()
+
+    def test_fetch_data_unknown_source_raises(self, viewser_loader):
+        """_fetch_data() with unknown source raises ValueError."""
+        with pytest.raises(ValueError, match="Unknown data source"):
+            viewser_loader._fetch_data(self_test=False, source="oracle")
+
+
+class TestCacheFilenames:
+
+    @patch("views_pipeline_core.modules.dataloaders.dataloaders.save_dataframe")
+    @patch("views_pipeline_core.modules.dataloaders.dataloaders.create_data_fetch_log_file")
+    def test_viewser_cache_filename_unchanged(
+        self, mock_log, mock_save, viewser_loader, sample_df
+    ):
+        """Viewser models still produce {partition}_viewser_df.parquet."""
+        with patch.object(viewser_loader, "_fetch_data_from_viewser", return_value=(sample_df, [])):
+            viewser_loader.get_data(
+                self_test=False, partition="calibration",
+                use_saved=False, validate=False,
+            )
+
+        saved_path = mock_save.call_args[0][1]
+        assert saved_path.name == "calibration_viewser_df.parquet"
+
+    @patch("views_pipeline_core.modules.dataloaders.dataloaders.save_dataframe")
+    @patch("views_pipeline_core.modules.dataloaders.dataloaders.create_data_fetch_log_file")
+    def test_datafactory_cache_filename(
+        self, mock_log, mock_save, datafactory_loader, sample_df
+    ):
+        """Datafactory models produce {partition}_datafactory_df.parquet."""
+        with patch.object(datafactory_loader, "_fetch_data_from_datafactory", return_value=(sample_df, None)):
+            datafactory_loader.get_data(
+                self_test=False, partition="calibration",
+                use_saved=False, validate=False,
+            )
+
+        saved_path = mock_save.call_args[0][1]
+        assert saved_path.name == "calibration_datafactory_df.parquet"
+
+    @patch("views_pipeline_core.modules.dataloaders.dataloaders.save_dataframe")
+    @patch("views_pipeline_core.modules.dataloaders.dataloaders.create_data_fetch_log_file")
+    def test_datafactory_cache_read(
+        self, mock_log, mock_save, datafactory_loader, sample_df, tmp_path
+    ):
+        """use_saved=True with existing datafactory cache reads from disk."""
+        cache_path = tmp_path / "calibration_datafactory_df.parquet"
+        sample_df.to_parquet(cache_path)
+
+        with patch.object(datafactory_loader, "_fetch_data_from_datafactory") as mock_fetch:
+            df, _ = datafactory_loader.get_data(
+                self_test=False, partition="calibration",
+                use_saved=True, validate=False,
+            )
+            mock_fetch.assert_not_called()
+            assert len(df) == len(sample_df)
+
+
+class TestHandleSingleLogCreation:
+
+    def test_missing_fetch_log_does_not_crash(self, tmp_path, caplog):
+        """handle_single_log_creation() proceeds when data_fetch_log.txt is absent."""
+        gen_dir = tmp_path / "generated"
+        gen_dir.mkdir()
+
+        mock_path = MagicMock()
+        mock_path.data_raw = tmp_path
+        mock_path.data_generated = gen_dir
+
+        config = {
+            "run_type": "calibration",
+            "timestamp": "20260422_010000",
+            "name": "test_model",
+            "deployment_status": "shadow",
+        }
+
+        with caplog.at_level(logging.WARNING):
+            handle_single_log_creation(mock_path, config, train=False)
+
+        assert "Data fetch log not found" in caplog.text
+
+    def test_existing_fetch_log_timestamp_used(self, tmp_path):
+        """handle_single_log_creation() reads timestamp when fetch log exists."""
+        gen_dir = tmp_path / "generated"
+        gen_dir.mkdir()
+
+        log_path = tmp_path / "calibration_data_fetch_log.txt"
+        log_path.write_text(
+            "Single Model Name: test\nData Fetch Timestamp: 20260421_120000\n"
+        )
+
+        mock_path = MagicMock()
+        mock_path.data_raw = tmp_path
+        mock_path.data_generated = gen_dir
+
+        config = {
+            "run_type": "calibration",
+            "timestamp": "20260422_010000",
+            "name": "test_model",
+            "deployment_status": "shadow",
+        }
+
+        handle_single_log_creation(mock_path, config, train=False)

--- a/views_pipeline_core/data/model_path.py
+++ b/views_pipeline_core/data/model_path.py
@@ -587,7 +587,8 @@ class ModelPathManager:
             f
             for f in self.data_raw.iterdir()
             if f.is_file()
-            and f.stem.startswith(f"{run_type}_viewser_df")
+            and (f.stem.startswith(f"{run_type}_viewser_df")
+                 or f.stem.startswith(f"{run_type}_datafactory_df"))
             and f.suffix == PipelineConfig.dataframe_format
         ]
         return sorted(paths, reverse=True)

--- a/views_pipeline_core/files/utils.py
+++ b/views_pipeline_core/files/utils.py
@@ -155,9 +155,19 @@ def handle_single_log_creation(model_path, config: dict, train: bool) -> None:
         None
     """
     timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
-    data_fetch_timestamp = read_log_file(
-        model_path.data_raw / f"{config['run_type']}_data_fetch_log.txt"
-    ).get("Data Fetch Timestamp", None)
+    fetch_log_path = model_path.data_raw / f"{config['run_type']}_data_fetch_log.txt"
+    if fetch_log_path.exists():
+        data_fetch_timestamp = read_log_file(fetch_log_path).get(
+            "Data Fetch Timestamp", None
+        )
+    else:
+        data_fetch_timestamp = None
+        logger.warning(
+            "Data fetch log not found at %s — data may have been loaded from "
+            "cache or fetched via a non-viewser source. Proceeding without "
+            "data fetch timestamp.",
+            fetch_log_path,
+        )
 
     create_log_file(
         path_generated=model_path.data_generated,

--- a/views_pipeline_core/managers/evaluation/stage.py
+++ b/views_pipeline_core/managers/evaluation/stage.py
@@ -136,18 +136,22 @@ class EvaluationStage:
             )
 
         if not raw_paths:
+            model_label = (
+                f"ensemble constituent model {context.configs['models'][0]}"
+                if ensemble
+                else f"model {context.model_path.model_name}"
+            )
             logger.error(
-                "No raw data file found for %s model %s (run_type=%s)",
-                "ensemble constituent" if ensemble else "",
-                context.configs["models"][0] if ensemble else context.model_path.model_name,
+                "No raw data file found for %s (run_type=%s)",
+                model_label,
                 context.run_type,
             )
             return None
         df_path = raw_paths[0]
 
-        df_viewser = read_dataframe(df_path)
-        logger.info(f"df_viewser read from {df_path}")
-        df_viewser = context.prepare_actuals_df(df_viewser)
+        df_raw = read_dataframe(df_path)
+        logger.info(f"Raw data read from {df_path}")
+        df_raw = context.prepare_actuals_df(df_raw)
 
         all_targets = (
             context.configs.get("regression_targets", [])
@@ -156,8 +160,8 @@ class EvaluationStage:
         if not all_targets:
             return None
 
-        df_actual = df_viewser[all_targets].copy()
-        del df_viewser
+        df_actual = df_raw[all_targets].copy()
+        del df_raw
         gc.collect()
         return df_actual
 

--- a/views_pipeline_core/managers/evaluation/stage.py
+++ b/views_pipeline_core/managers/evaluation/stage.py
@@ -121,20 +121,29 @@ class EvaluationStage:
         )
 
     def _load_actuals(self, context: EvaluationContext, ensemble: bool):
-        """Load and prepare actuals DataFrame from raw viewser data."""
-        from views_pipeline_core.configs.pipeline import PipelineConfig
+        """Load and prepare actuals DataFrame from raw data."""
         from views_pipeline_core.files.utils import read_dataframe
 
         if not ensemble:
-            df_path = context.model_path._get_raw_data_file_paths(
+            raw_paths = context.model_path._get_raw_data_file_paths(
                 run_type=context.run_type
-            )[0]
+            )
         else:
             from views_pipeline_core.managers.model import ModelPathManager
-            df_path = (
-                ModelPathManager(context.configs["models"][0]).data_raw
-                / f"{context.configs['run_type']}_viewser_df{PipelineConfig.dataframe_format}"
+            mp = ModelPathManager(context.configs["models"][0])
+            raw_paths = mp._get_raw_data_file_paths(
+                run_type=context.configs["run_type"]
             )
+
+        if not raw_paths:
+            logger.error(
+                "No raw data file found for %s model %s (run_type=%s)",
+                "ensemble constituent" if ensemble else "",
+                context.configs["models"][0] if ensemble else context.model_path.model_name,
+                context.run_type,
+            )
+            return None
+        df_path = raw_paths[0]
 
         df_viewser = read_dataframe(df_path)
         logger.info(f"df_viewser read from {df_path}")

--- a/views_pipeline_core/modules/dataloaders/dataloaders.py
+++ b/views_pipeline_core/modules/dataloaders/dataloaders.py
@@ -1203,7 +1203,7 @@ class ViewsDataLoader:
 
         return df, None
 
-    def _fetch_data(self, self_test: bool, source: str) -> tuple[pd.DataFrame, list]:
+    def _fetch_data(self, self_test: bool, source: str) -> tuple[pd.DataFrame, list | None]:
         """Dispatch to the correct fetch strategy based on detected source.
 
         Args:

--- a/views_pipeline_core/modules/dataloaders/dataloaders.py
+++ b/views_pipeline_core/modules/dataloaders/dataloaders.py
@@ -1203,6 +1203,30 @@ class ViewsDataLoader:
 
         return df, None
 
+    def _fetch_data(self, self_test: bool, source: str) -> tuple[pd.DataFrame, list]:
+        """Dispatch to the correct fetch strategy based on detected source.
+
+        Args:
+            self_test: Whether to perform drift detection self-testing.
+            source: Data source identifier ('viewser' or 'datafactory')
+                as returned by _detect_data_source().
+
+        Returns:
+            Tuple of (dataframe, alerts_or_None).
+
+        Raises:
+            ValueError: If source is not recognized.
+        """
+        if source == "viewser":
+            return self._fetch_data_from_viewser(self_test)
+        elif source == "datafactory":
+            return self._fetch_data_from_datafactory(self_test)
+        else:
+            raise ValueError(
+                f"Unknown data source '{source}' for model {self._model_name}. "
+                f"Expected 'viewser' or 'datafactory'."
+            )
+
     def _get_month_range(self) -> tuple[int, int]:
         """
         Determine month range based on partition type.
@@ -1384,38 +1408,40 @@ class ViewsDataLoader:
         if self.month_first is None or self.month_last is None:
             self.month_first, self.month_last = self._get_month_range()
 
-        path_viewser_df = Path(
-            os.path.join(str(self._path_raw), f"{self.partition}_viewser_df{PipelineConfig.dataframe_format}")
-        )  
+        source = self._detect_data_source()
+        cache_label = "viewser" if source == "viewser" else "datafactory"
+        path_cached_df = Path(
+            os.path.join(str(self._path_raw), f"{self.partition}_{cache_label}_df{PipelineConfig.dataframe_format}")
+        )
         alerts = None
 
         if use_saved:
-            if path_viewser_df.exists():
+            if path_cached_df.exists():
                 try:
-                    df = read_dataframe(path_viewser_df)
-                    logger.info(f"Reading saved data from {path_viewser_df}")
+                    df = read_dataframe(path_cached_df)
+                    logger.info(f"Reading saved data from {path_cached_df}")
                 except Exception as e:
                     raise RuntimeError(
-                        f"Use of saved data was specified but getting {path_viewser_df} failed with: {e}"
+                        f"Use of saved data was specified but getting {path_cached_df} failed with: {e}"
                     )
             else:
-                logger.info(f"Saved data not found at {path_viewser_df}, fetching from viewser...")
-                df, alerts = self._fetch_data_from_viewser(self_test)
+                logger.info(f"Saved data not found at {path_cached_df}, fetching from {source}...")
+                df, alerts = self._fetch_data(self_test, source)
                 data_fetch_timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
                 create_data_fetch_log_file(
                     self._path_raw, self.partition, self._model_name, data_fetch_timestamp
                 )
-                logger.info(f"Saving data to {path_viewser_df}")
-                save_dataframe(df, path_viewser_df)
+                logger.info(f"Saving data to {path_cached_df}")
+                save_dataframe(df, path_cached_df)
         else:
-            logger.info("Fetching data from viewser...")
-            df, alerts = self._fetch_data_from_viewser(self_test) 
+            logger.info(f"Fetching data from {source}...")
+            df, alerts = self._fetch_data(self_test, source)
             data_fetch_timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
             create_data_fetch_log_file(
                 self._path_raw, self.partition, self._model_name, data_fetch_timestamp
             )
-            logger.info(f"Saving data to {path_viewser_df}")
-            save_dataframe(df, path_viewser_df)
+            logger.info(f"Saving data to {path_cached_df}")
+            save_dataframe(df, path_cached_df)
             
         if validate:
             CoreDataSniffer(

--- a/views_pipeline_core/modules/validation/ensemble/check.py
+++ b/views_pipeline_core/modules/validation/ensemble/check.py
@@ -176,19 +176,18 @@ def validate_ensemble_raw_data_alignment(model_names, run_type):
         True if all models have consistent raw data, False otherwise
     """
     from views_pipeline_core.data.model_path import ModelPathManager
-    from views_pipeline_core.configs.pipeline import PipelineConfig
 
     if len(model_names) <= 1:
         return True
 
-    filename = f"{run_type}_viewser_df{PipelineConfig.dataframe_format}"
     sizes = {}
     for name in model_names:
-        path = ModelPathManager(name).data_raw / filename
-        if not path.exists():
-            logger.warning(f"Raw data file missing for model {name}: {path}")
+        mp = ModelPathManager(name)
+        raw_paths = mp._get_raw_data_file_paths(run_type)
+        if not raw_paths:
+            logger.warning("Raw data file missing for model %s", name)
             continue
-        sizes[name] = path.stat().st_size
+        sizes[name] = raw_paths[0].stat().st_size
 
     if not sizes:
         return True
@@ -196,9 +195,11 @@ def validate_ensemble_raw_data_alignment(model_names, run_type):
     unique_sizes = set(sizes.values())
     if len(unique_sizes) > 1:
         logger.warning(
-            f"Ensemble raw data inconsistency: models have different file sizes "
-            f"for {filename}. This may indicate different querysets. "
-            f"Sizes: {sizes}"
+            "Ensemble raw data inconsistency: models have different file sizes "
+            "for run_type=%s. This may indicate different querysets. "
+            "Sizes: %s",
+            run_type,
+            sizes,
         )
         return False
 


### PR DESCRIPTION
## Summary

- **THE behavioral change**: `get_data()` now detects the data source via `_detect_data_source()`, constructs source-aware cache filenames, and dispatches to the correct fetch method
- Fixes 5 downstream `_viewser_df` hardcoded sites: `model_path.py`, `evaluation/stage.py`, `ensemble/check.py`, `files/utils.py`
- 73 existing viewser models unaffected — cache filenames stay `{partition}_viewser_df.parquet`, fetch path identical

### Changes (7 total across 5 production files)

1. **`dataloaders.py`** — `_fetch_data()` dispatch helper + `get_data()` rewired with source detection, `path_cached_df`, source-aware log messages
2. **`files/utils.py`** — `handle_single_log_creation()` tolerates missing fetch log (warns instead of crashing)
3. **`model_path.py`** — `_get_raw_data_file_paths()` OR-matches `_viewser_df` and `_datafactory_df`
4. **`evaluation/stage.py`** — Ensemble actuals loading uses `_get_raw_data_file_paths()` instead of hardcoded filename
5. **`ensemble/check.py`** — Alignment check uses `_get_raw_data_file_paths()` instead of hardcoded filename

PR 4 of 5 in the viewser→views-datafactory migration ([roadmap](reports/adress_non-viewser_data_sources/ROADMAP.md)). Resolves C-51, C-53, C-14. Mitigates C-58.

## Test plan

- [x] 8 new dispatch tests (`test_get_data_dispatch.py`): routing, cache filenames, cache read, unknown source, log resilience
- [x] 3 characterization tests updated: dict descriptor dispatch, missing fetch log warning, datafactory file discovery
- [x] 1 ensemble check test updated for new `_get_raw_data_file_paths()` API
- [x] All 48 PR-related tests pass
- [x] Full suite: 1141 passed (2 pre-existing ordering-dependent failures, 6 pre-existing fixture errors)
- [x] `ruff check` clean on all 8 changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)