### PR TITLE
feat: PF ensemble prerequisites and CIC

### DIFF
--- a/documentation/CICs/PredictionFrameEnsembleManager.md
+++ b/documentation/CICs/PredictionFrameEnsembleManager.md
@@ -1,0 +1,289 @@
+# Class Intent Contract: PredictionFrameEnsembleManager
+
+**Status:** Active
+**Owner:** Orchestration Core
+**Last reviewed:** 2026-05-21
+**Related ADRs:** ADR-042 (PredictionFrame), ADR-045 (Stage Pattern), ADR-051 (Composition-Based Ensemble Architecture)
+
+---
+
+## 1. Purpose
+
+Composition-based ensemble orchestrator for the PredictionFrame (numpy) prediction
+path. ADR-051 Phase 2. Resolves C-66 (OOM on DataFrame ensemble aggregation with
+sample-based models) by keeping predictions in numpy format throughout — no
+conversion to DataFrame or parquet at any point.
+
+Handles HydraNet-class ensembles where each sub-model produces `(N, S)` posterior
+sample arrays. Aggregation is pure numpy: `np.concatenate` (stacking samples) or
+`np.mean(np.stack(...))` (averaging samples).
+
+All ensemble-specific business logic is intentionally copied from
+`DataFrameEnsembleManager` (WET-before-DRY). The architectural difference is the
+data format: `PredictionFrame` numpy arrays instead of `pd.DataFrame`.
+
+---
+
+## 2. Non-Goals (Explicit Exclusions)
+
+- Does **not** inherit from `ForecastingModelManager`, `ModelManager`, or any base
+  class. This is a deliberate architectural choice, not an omission.
+- Does **not** replace `EnsembleManager` or `DataFrameEnsembleManager`. All three
+  classes coexist (Strangler Fig pattern). Existing ensembles continue unchanged.
+- Does **not** support the DataFrame/parquet code path. That belongs to
+  `DataFrameEnsembleManager`.
+- Does **not** implement reconciliation. Reconciliation is a point-prediction
+  operation; PredictionFrame carries posterior samples where reconciliation has
+  no defined semantics.
+- Does **not** implement model-specific training or inference. Sub-models are
+  invoked via shell subprocesses.
+- Does **not** own complex aggregation logic (`AggregationModule`). Uses pure
+  numpy functions for concat and arithmetic mean.
+- Does **not** manage WandB run lifecycle inside stages. The `_execute_*` methods
+  are the lifecycle boundary; stages contain only business logic.
+- Does **not** support prediction store upload (`use_prediction_store` is always
+  `False` for sub-model dispatch). No prediction store API exists for numpy format.
+
+---
+
+## 3. Responsibilities and Guarantees
+
+- Guarantees that predictions **never** convert to DataFrame or parquet. The
+  entire pipeline is numpy: `y_pred.npy` + `identifiers.npz` via
+  `PredictionFrame.save()/load()`.
+- Guarantees that `CoreConfigSniffer.sniff_all()` runs before WandB login or any
+  model execution.
+- Guarantees that an immutable `EnsembleContext` (frozen dataclass, imported from
+  `dataframe_ensemble.py`) is built once in `execute_single_run()` and threaded to
+  every method. Context always has `prediction_format="prediction_frame"` and
+  `reconciliation=None`.
+- Guarantees that `EvaluationStage` and `ReportingStage` are used via composition
+  (injected at construction), not via inheritance.
+- Guarantees that all sub-models in `configs["models"]` are trained, evaluated,
+  or forecasted depending on requested stages.
+- Guarantees that `_aggregate_prediction_frames()` validates input before
+  aggregation: non-empty list, identical `n_rows`, identical identifiers (time/unit
+  arrays must be `np.array_equal`), supported method.
+- Guarantees that all sub-models return the same number of evaluation outputs per
+  target; raises `ValueError` if any model returns fewer.
+- Guarantees that `validate_ensemble_model(configs)` is called before execution
+  when `args.train is False`.
+- Guarantees that subprocess execution uses `timeout=7200` seconds.
+- Guarantees cache-first loading: `_load_or_generate_pf()` checks for existing
+  `y_pred.npy` before dispatching a subprocess.
+- Guarantees that aggregated PFs are saved to disk via `PredictionFrame.save()`
+  before evaluation or reporting.
+
+---
+
+## 4. Inputs and Assumptions
+
+- `ensemble_path: EnsemblePathManager` -- must point to a valid ensemble
+  directory under `ensembles/`.
+- `wandb_notifications: bool` -- gate for WandB alerts.
+- `use_prediction_store: bool` -- accepted for API symmetry with
+  `DataFrameEnsembleManager` but functionally unused (sub-models always get
+  `prediction_store=False`).
+- `execute_single_run(args: ForecastingModelArgs)` -- must receive a
+  `ForecastingModelArgs` instance; raises `ValueError` otherwise.
+- Config files (`config_deployment.py`, `config_hyperparameters.py`,
+  `config_meta.py`, `config_partitions.py`) are loaded via `importlib` from
+  `ensemble_path.get_scripts()`.
+- `configs["models"]` -- list of sub-model names, each resolvable by
+  `ModelPathManager`.
+- `configs["aggregation"]` -- must be in `SUPPORTED_PF_AGGREGATION_METHODS`:
+  `{"concat", "arithmetic_mean"}`.
+- `configs["targets"]` or `configs["regression_targets"]` -- list of target names.
+- Assumes sub-model `main.py` scripts accept `ForecastingModelArgs.to_shell_command()`
+  arguments and produce PredictionFrame outputs at:
+  - Evaluation: `data_generated/predictions_{run_type}_{ts}/origin_{i}/{target}/y_pred.npy`
+  - Forecast: `data_generated/predictions_{run_type}_{ts}/{target}/y_pred.npy`
+
+---
+
+## 5. Outputs and Side Effects
+
+- Executes sub-model `main.py` as shell subprocesses via `subprocess.run()`.
+- Creates aggregated PredictionFrame directories in `ensemble_path.data_generated/`:
+  - Evaluation: `predictions_{run_type}_{ts}/origin_{i}/{target}/y_pred.npy`
+  - Forecast: `predictions_{run_type}_{ts}/{target}/y_pred.npy`
+- Creates ensemble log entries via `handle_ensemble_log_creation`.
+- Creates WandB runs for `train`, `evaluate`, `forecast`, and `report` stages.
+- Delegates evaluation to `EvaluationStage.evaluate()` with `ensemble=True` and
+  `prediction_format="prediction_frame"`.
+- Delegates reporting to `ReportingStage.generate_forecast_report()` and
+  `generate_evaluation_report()`.
+- Uses `mmap=True` when loading sub-model PFs during evaluation (memory-bounded
+  sequential access).
+
+---
+
+## 6. Failure Modes and Loudness
+
+| Condition | Behaviour |
+|---|---|
+| `args` is not `ForecastingModelArgs` | `ValueError` immediately |
+| `CoreConfigSniffer.sniff_all()` fails | Exception propagates; no WandB login or execution |
+| `wandb_module.login()` fails | `RuntimeError` propagates (C-85 coverage) |
+| Sub-model subprocess fails | `PipelineException` with WandB alert |
+| Sub-model subprocess times out (>7200s) | `PipelineException` with timeout message |
+| Sub-models return different output counts | `ValueError` in `_evaluate_ensemble()` |
+| No PredictionFrame output found after subprocess | `PipelineException` with `logger.error` (ADR-008 compliant) |
+| `_aggregate_prediction_frames([])` | `ValueError`: "requires at least one PredictionFrame" |
+| Mismatched `n_rows` between PFs | `ValueError` identifying which frame mismatches |
+| Mismatched identifiers between PFs | `ValueError` identifying which key differs |
+| Unsupported aggregation method | `ValueError` listing supported methods |
+| Sub-model did not produce forecast for target | `ValueError` in `_forecast_ensemble()` |
+| Training/evaluation/forecasting exception | `PipelineException` with traceback and WandB alert |
+
+All failures are loud. No silent fallbacks.
+
+---
+
+## 7. Boundaries and Interactions
+
+```
+PredictionFrameEnsembleManager (composition, no inheritance)
+    |-- EnsemblePathManager        (path resolution for ensembles/)
+    |-- ModelPathManager           (path resolution for each sub-model)
+    |-- ForecastingModelArgs       (CLI args, converted to shell commands)
+    |-- subprocess.run()           (sub-model execution, timeout=7200)
+    |-- CoreConfigSniffer          (pre-flight config validation)
+    |-- ConfigurationManager       (config merging and WandB integration)
+    |-- _aggregate_prediction_frames()  (pure numpy aggregation)
+    |-- PredictionFrame.save/load  (numpy persistence, mmap support)
+    |
+    |-- Composed stages (ADR-045):
+    |   |-- EvaluationStage        (metric computation, ensemble=True)
+    |   |-- ReportingStage         (HTML report generation)
+    |
+    |-- WandBModule                (alerts, run lifecycle)
+    |-- LoggingModule              (logging setup)
+```
+
+- **Depends on:** `ForecastingModelManager._resolve_evaluation_sequence_number()`
+  (static method) for determining evaluation sequence count.
+- **Depends on:** `EnsembleContext` (frozen dataclass from `dataframe_ensemble.py`).
+- **Does not depend on:** `ForecastingModelManager` instance state, `ViewsDataLoader`,
+  `ForecastingStage`, `PredictionIOManager`, `AggregationModule`,
+  `ReconciliationModule`, or any DataFrame conversion.
+
+---
+
+## 8. Examples of Correct Usage
+
+```python
+from views_pipeline_core.managers.ensemble import PredictionFrameEnsembleManager, EnsemblePathManager
+from views_pipeline_core.cli.args import ForecastingModelArgs
+
+ensemble_path = EnsemblePathManager("synthetic_chorus")
+manager = PredictionFrameEnsembleManager(
+    ensemble_path=ensemble_path,
+    wandb_notifications=True,
+)
+args = ForecastingModelArgs(
+    run_type="calibration",
+    train=False,
+    evaluate=True,
+    forecast=True,
+    saved=True,
+    eval_type="standard",
+)
+manager.execute_single_run(args)
+```
+
+---
+
+## 9. Examples of Incorrect Usage
+
+```python
+# WRONG: passing ModelPathManager instead of EnsemblePathManager
+manager = PredictionFrameEnsembleManager(ensemble_path=ModelPathManager("purple_alien"))
+# -> Will look in models/ instead of ensembles/
+
+# WRONG: using for DataFrame-based models (parquet predictions)
+# -> PredictionFrameEnsembleManager only handles PredictionFrame (numpy) outputs.
+#    Use DataFrameEnsembleManager for point-prediction ensembles.
+
+# WRONG: expecting reconciliation to work
+# -> reconciliation is always None. PredictionFrame carries posterior samples;
+#    hierarchical reconciliation has no defined semantics for sample arrays.
+
+# WRONG: calling methods directly without execute_single_run()
+manager._evaluate_ensemble(ctx)
+# -> EnsembleContext is not built; _args is None; CoreConfigSniffer has not run.
+
+# WRONG: using aggregation methods other than concat/arithmetic_mean
+# -> configs["aggregation"] = "median" will raise ValueError
+```
+
+---
+
+## 10. Test Alignment
+
+- `tests/test_managers/test_prediction_frame_ensemble_manager.py` -- 43
+  characterization tests across 8 test classes:
+  - `TestPredictionFrameAggregation` (9 tests) -- verifies concat stacks samples
+    axis, arithmetic mean averages correctly, identifiers are preserved, mismatches
+    raise, empty list raises, unsupported method raises.
+  - `TestPredictionFrameEnsembleConstants` (4 tests) -- verifies
+    `SUPPORTED_PF_AGGREGATION_METHODS` is frozenset, EnsembleContext accepts
+    `prediction_format="prediction_frame"`, context is frozen.
+  - `TestPredictionFrameEnsembleConstruction` (6 tests) -- verifies no inheritance
+    from ModelManager/ForecastingModelManager, composed stages exist, path stored.
+  - `TestPredictionFrameLoading` (5 tests) -- verifies cache-first loading, generate
+    when missing, exception when no output, mmap flag passthrough.
+  - `TestPredictionFrameEvaluationFlow` (2 tests) -- verifies aggregation per
+    sequence and prediction_format propagation to EvaluationStage.
+  - `TestPredictionFrameForecastingFlow` (4 tests) -- verifies aggregation across
+    models, PF save, no reconciliation method, return type is Dict[str, PF].
+  - `TestPredictionFrameTrainingFlow` (2 tests) -- verifies subprocess dispatch per
+    model and train flag passthrough.
+  - `TestPredictionFrameEntryPoint` (11 tests) -- verifies args validation, sniffer
+    call, wandb login (and failure propagation), task dispatch, subprocess timeout/
+    failure → PipelineException, validation gating.
+
+---
+
+## 11. Evolution Notes
+
+- This class proves the PredictionFrame path for ensemble orchestration, enabling
+  HydraNet production ensembles with 64 posterior samples per observation.
+- Business logic is intentionally WET (copied from `DataFrameEnsembleManager`).
+  Once both composition-based managers are proven in production, shared abstractions
+  may be extracted.
+- The dependency on `ForecastingModelManager._resolve_evaluation_sequence_number()`
+  is a static method call. It may be relocated to a utility module.
+- Future work: `prediction_store` support for numpy format (blocked on views-forecasts
+  package numpy API). When available, `_create_model_args` can pass
+  `prediction_store=True`.
+- Sub-model numpy directory discovery relies on explicit path construction from the
+  model artifact timestamp. The utility method `_get_generated_pf_prediction_paths()`
+  on `ModelPathManager` provides an alternative lookup mechanism.
+
+---
+
+## 12. Known Deviations
+
+- **No reconciliation:** Unlike `DataFrameEnsembleManager`, this class has no
+  reconciliation path. The `reconciliation` field in `EnsembleContext` is always
+  set to `None`.
+- **No `PredictionIOManager`:** `EvaluationStage` is constructed with
+  `io_manager=None`. All persistence is via `PredictionFrame.save()` directly.
+- **Subprocess stderr not captured:** Sub-models invoked via `subprocess.run()`
+  with `check=True`. A sub-model that fails silently (exit code 0, garbage output)
+  is not detected until aggregation or loading.
+- **`handle_ensemble_log_creation` called in both eval and forecast
+  `_execute_*` methods:** This matches the DataFrameEnsembleManager pattern.
+  Log creation is an orchestration-level side effect, not a business-logic concern.
+- **`EnsembleContext` imported from `dataframe_ensemble.py`:** Shared frozen
+  dataclass. If the two managers diverge in context needs, a separate context
+  class should be created.
+
+---
+
+## End of Contract
+
+This document defines the **intended meaning** of `PredictionFrameEnsembleManager`.
+Changes to behavior that violate this intent are bugs.
+Changes to intent must update this contract.

--- a/tests/test_managers/test_execute_model_evaluation.py
+++ b/tests/test_managers/test_execute_model_evaluation.py
@@ -369,3 +369,155 @@ class TestSequenceCountValidation:
         from views_pipeline_core.exceptions import ModelEvaluationException
         with pytest.raises(ModelEvaluationException, match="Evaluation failed"):
             manager._execute_model_evaluation()
+
+
+# ============================================================
+# PATH 7: PF permanent persistence for ensemble consumption
+# ============================================================
+
+
+class TestPFPermanentPersistence:
+    """Verify PF evaluation path persists to ensemble-discoverable location."""
+
+    @patch("views_pipeline_core.files.utils.handle_single_log_creation")
+    def test_pf_eval_persists_to_permanent_location(self, mock_log_creation, tmp_path):
+        """PF origin_sink must save to data_generated/predictions_{run_type}_{ts}/origin_{i}/{target}/."""
+        import numpy as np
+        from views_pipeline_core.data.prediction_frame import PredictionFrame
+
+        manager = _make_manager()
+        manager._model_path.data_generated = tmp_path / "data" / "generated"
+        manager._model_path.data_generated.mkdir(parents=True)
+
+        pf_configs = dict(manager.configs)
+        pf_configs["prediction_format"] = "prediction_frame"
+        pf_configs["skip_evaluation_metrics"] = True
+        pf_configs["skip_predictions_delivery"] = True
+        pf_configs["timestamp"] = "20260501_120000"
+        manager._config_manager.get_combined_config.return_value = pf_configs
+
+        pf = PredictionFrame(
+            y_pred=np.ones((10, 4), dtype=np.float32),
+            identifiers={"time": np.arange(10), "unit": np.arange(10)},
+        )
+
+        def fake_streaming(eval_type, artifact_name, origin_sink):
+            origin_sink(0, {"target_sb": pf})
+
+        manager._evaluate_model_artifact_streaming = MagicMock(
+            side_effect=fake_streaming
+        )
+
+        manager._execute_model_evaluation()
+
+        permanent_dir = (
+            manager._model_path.data_generated
+            / "predictions_calibration_20260501_120000"
+            / "origin_0"
+            / "target_sb"
+        )
+        assert (permanent_dir / "y_pred.npy").exists()
+        assert (permanent_dir / "identifiers.npz").exists()
+
+    @patch("views_pipeline_core.files.utils.handle_single_log_creation")
+    def test_pf_eval_staging_cleaned_up_after_metrics(self, mock_log_creation, tmp_path):
+        """Staging path must be cleaned up after evaluation completes."""
+        import numpy as np
+        from views_pipeline_core.data.prediction_frame import PredictionFrame
+
+        manager = _make_manager()
+        manager._model_path.data_generated = tmp_path / "data" / "generated"
+        manager._model_path.data_generated.mkdir(parents=True)
+
+        pf_configs = dict(manager.configs)
+        pf_configs["prediction_format"] = "prediction_frame"
+        pf_configs["skip_evaluation_metrics"] = True
+        pf_configs["skip_predictions_delivery"] = True
+        pf_configs["timestamp"] = "20260501_120000"
+        manager._config_manager.get_combined_config.return_value = pf_configs
+
+        pf = PredictionFrame(
+            y_pred=np.ones((10, 4), dtype=np.float32),
+            identifiers={"time": np.arange(10), "unit": np.arange(10)},
+        )
+
+        def fake_streaming(eval_type, artifact_name, origin_sink):
+            origin_sink(0, {"target_sb": pf})
+
+        manager._evaluate_model_artifact_streaming = MagicMock(
+            side_effect=fake_streaming
+        )
+
+        manager._execute_model_evaluation()
+
+        staging_dir = manager._model_path.data_generated / "_pf_staging"
+        assert not staging_dir.exists()
+
+
+# ============================================================
+# PATH 8: PF forecast permanent persistence
+# ============================================================
+
+
+class TestPFForecastPersistence:
+    """Verify PF forecast path persists to ensemble-discoverable location."""
+
+    def test_pf_forecast_persists_to_data_generated(self, tmp_path):
+        """PF forecast must save to data_generated/predictions_{run_type}_{ts}/{target}/."""
+        import numpy as np
+        from views_pipeline_core.data.prediction_frame import PredictionFrame
+
+        manager = _make_manager()
+        manager._model_path.data_generated = tmp_path / "data" / "generated"
+        manager._model_path.data_generated.mkdir(parents=True)
+
+        pf_configs = dict(manager.configs)
+        pf_configs["prediction_format"] = "prediction_frame"
+        pf_configs["timestamp"] = "20260501_120000"
+        manager._config_manager.get_combined_config.return_value = pf_configs
+
+        pf = PredictionFrame(
+            y_pred=np.ones((10, 4), dtype=np.float32),
+            identifiers={"time": np.arange(10), "unit": np.arange(10)},
+        )
+        manager._forecast_model_artifact = MagicMock(
+            return_value={"target_sb": pf}
+        )
+        manager._forecasting_stage = MagicMock()
+
+        manager._execute_model_forecasting()
+
+        pf_dir = (
+            manager._model_path.data_generated
+            / "predictions_calibration_20260501_120000"
+            / "target_sb"
+        )
+        assert (pf_dir / "y_pred.npy").exists()
+        assert (pf_dir / "identifiers.npz").exists()
+
+    def test_pf_forecast_still_calls_forecasting_stage(self, tmp_path):
+        """PF save must not prevent ForecastingStage from running."""
+        import numpy as np
+        from views_pipeline_core.data.prediction_frame import PredictionFrame
+
+        manager = _make_manager()
+        manager._model_path.data_generated = tmp_path / "data" / "generated"
+        manager._model_path.data_generated.mkdir(parents=True)
+
+        pf_configs = dict(manager.configs)
+        pf_configs["prediction_format"] = "prediction_frame"
+        pf_configs["timestamp"] = "20260501_120000"
+        manager._config_manager.get_combined_config.return_value = pf_configs
+
+        pf = PredictionFrame(
+            y_pred=np.ones((10, 4), dtype=np.float32),
+            identifiers={"time": np.arange(10), "unit": np.arange(10)},
+        )
+        manager._forecast_model_artifact = MagicMock(
+            return_value={"target_sb": pf}
+        )
+        manager._forecasting_stage = MagicMock()
+
+        manager._execute_model_forecasting()
+
+        manager._forecasting_stage.process_and_save_forecast.assert_called_once()

--- a/tests/test_managers/test_model_manager_prediction_format.py
+++ b/tests/test_managers/test_model_manager_prediction_format.py
@@ -130,8 +130,9 @@ def _run_execute_forecast(manager, mock_df_result=None):
         "views_pipeline_core.modules.validation.core_prediction_sniffer.CorePredictionSniffer"
     ) as MockSniffer:
         with patch("views_pipeline_core.files.utils.handle_single_log_creation"):
-            manager._execute_model_forecasting()
-            return MockSniffer
+            with patch.object(PredictionFrame, "save"):
+                manager._execute_model_forecasting()
+                return MockSniffer
 
 
 # ── Phase 4A: Forecast dispatch ───────────────────────────────────────────────
@@ -825,10 +826,11 @@ class TestPFDictDispatch:
         manager._test_return = {"lr_sb": pf}
         dummy_df = _make_dummy_df()
 
-        with patch.object(
-            PredictionFrameConverter, "to_prediction_df", return_value=dummy_df
-        ) as mock_tld:
-            _run_execute_forecast(manager, mock_df_result=dummy_df)
+        with patch.object(PredictionFrame, "save"):
+            with patch.object(
+                PredictionFrameConverter, "to_prediction_df", return_value=dummy_df
+            ) as mock_tld:
+                _run_execute_forecast(manager, mock_df_result=dummy_df)
 
         mock_tld.assert_called_once()
 
@@ -843,9 +845,10 @@ class TestPFDictDispatch:
         manager._test_return = {"lr_sb": pf1, "ged_ns": pf2}
         dummy_df = _make_dummy_df()
 
-        with patch.object(PredictionFrameConverter, "to_legacy_dfs", return_value=[dummy_df]):
-            with patch.object(PredictionFrameConverter, "audit_prediction_structure"):
-                _run_execute_forecast(manager, mock_df_result=dummy_df)
+        with patch.object(PredictionFrame, "save"):
+            with patch.object(PredictionFrameConverter, "to_legacy_dfs", return_value=[dummy_df]):
+                with patch.object(PredictionFrameConverter, "audit_prediction_structure"):
+                    _run_execute_forecast(manager, mock_df_result=dummy_df)
 
         # E4: saves now go through ForecastingStage → io_manager, not facade._save_predictions
         assert manager._io.save_predictions.call_count == 2

--- a/tests/test_managers/test_model_path.py
+++ b/tests/test_managers/test_model_path.py
@@ -604,3 +604,80 @@ class TestIntegration:
         # Check paths have correct structure
         assert manager.model_dir.parent == manager.models
         assert manager.models.parent == manager.root
+
+
+# ============================================================================
+# Test PredictionFrame Discovery
+# ============================================================================
+
+class TestPFPredictionDiscovery:
+    def test_finds_numpy_prediction_dirs(self, mock_project_root):
+        manager = ModelPathManager("purple_alien", validate=True)
+
+        pf_dir = manager.data_generated / "predictions_calibration_20241105_120000"
+        pf_dir.mkdir(parents=True)
+        (pf_dir / "y_pred.npy").touch()
+
+        paths = manager._get_generated_pf_prediction_paths("calibration")
+        assert len(paths) == 1
+        assert paths[0] == pf_dir
+
+    def test_ignores_parquet_files(self, mock_project_root):
+        manager = ModelPathManager("purple_alien", validate=True)
+
+        (manager.data_generated / "predictions_calibration_20241105.parquet").touch()
+
+        paths = manager._get_generated_pf_prediction_paths("calibration")
+        assert len(paths) == 0
+
+    def test_ignores_dirs_without_y_pred(self, mock_project_root):
+        manager = ModelPathManager("purple_alien", validate=True)
+
+        empty_dir = manager.data_generated / "predictions_calibration_20241105_120000"
+        empty_dir.mkdir(parents=True)
+
+        paths = manager._get_generated_pf_prediction_paths("calibration")
+        assert len(paths) == 0
+
+    def test_sorted_newest_first(self, mock_project_root):
+        manager = ModelPathManager("purple_alien", validate=True)
+
+        for ts in ["20241101_100000", "20241105_120000", "20241103_090000"]:
+            d = manager.data_generated / f"predictions_calibration_{ts}"
+            d.mkdir(parents=True)
+            (d / "y_pred.npy").touch()
+
+        paths = manager._get_generated_pf_prediction_paths("calibration")
+        assert len(paths) == 3
+        assert "20241105" in paths[0].name
+        assert "20241103" in paths[1].name
+        assert "20241101" in paths[2].name
+
+    def test_filters_by_run_type(self, mock_project_root):
+        manager = ModelPathManager("purple_alien", validate=True)
+
+        for run_type in ["calibration", "validation"]:
+            d = manager.data_generated / f"predictions_{run_type}_20241105_120000"
+            d.mkdir(parents=True)
+            (d / "y_pred.npy").touch()
+
+        cal_paths = manager._get_generated_pf_prediction_paths("calibration")
+        val_paths = manager._get_generated_pf_prediction_paths("validation")
+        assert len(cal_paths) == 1
+        assert len(val_paths) == 1
+
+    def test_ignores_staging_dirs(self, mock_project_root):
+        manager = ModelPathManager("purple_alien", validate=True)
+
+        staging = manager.data_generated / "_pf_staging"
+        staging.mkdir(parents=True)
+        (staging / "y_pred.npy").touch()
+
+        paths = manager._get_generated_pf_prediction_paths("calibration")
+        assert len(paths) == 0
+
+    def test_empty_data_generated_returns_empty(self, mock_project_root):
+        manager = ModelPathManager("purple_alien", validate=True)
+
+        paths = manager._get_generated_pf_prediction_paths("calibration")
+        assert paths == []

--- a/views_pipeline_core/data/model_path.py
+++ b/views_pipeline_core/data/model_path.py
@@ -618,6 +618,34 @@ class ModelPathManager:
         ]
         return sorted(paths, reverse=True)
 
+    def _get_generated_pf_prediction_paths(self, run_type: str) -> List[Path]:
+        """
+        Get generated PredictionFrame directories for run type.
+
+        Finds directories in data_generated/ that contain y_pred.npy
+        and match the predictions_{run_type}_* naming convention.
+
+        Internal Use:
+            Used by ensemble managers to discover sub-model numpy outputs.
+
+        Args:
+            run_type: Run type ('calibration', 'validation', 'forecasting')
+
+        Returns:
+            Sorted list of prediction directory paths (newest first)
+        """
+        if not self.data_generated.exists():
+            return []
+        paths = [
+            d
+            for d in self.data_generated.iterdir()
+            if d.is_dir()
+            and d.name.startswith(f"predictions_{run_type}")
+            and not d.name.startswith("_")
+            and (d / "y_pred.npy").exists()
+        ]
+        return sorted(paths, key=lambda p: p.name, reverse=True)
+
     def get_latest_model_artifact_path(self, run_type: str) -> Path:
         """
         Get path to latest model artifact for run type.

--- a/views_pipeline_core/managers/model/model.py
+++ b/views_pipeline_core/managers/model/model.py
@@ -1290,6 +1290,8 @@ class ForecastingModelManager(ModelManager):
                     )
                     converter = PredictionFrameConverter()
                     staging_path = self._model_path.data_generated / "_pf_staging"
+                    _run_type = self.args.run_type
+                    _ts = self.configs.get("timestamp", "")
                     all_targets: List[str] = []
                     n_sequences = 0
 
@@ -1311,8 +1313,15 @@ class ForecastingModelManager(ModelManager):
                                 )
                         for target in list(pf_dict.keys()):
                             pf = pf_dict.pop(target)  # remove from dict → refcount drops
-                            # Track A — compact numpy (metrics)
+                            # Track A — compact numpy (metrics mmap reload)
                             pf.save(staging_path / f"origin_{origin_idx}" / target)
+                            # Track A+ — permanent numpy for ensemble consumption
+                            pf.save(
+                                self._model_path.data_generated
+                                / f"predictions_{_run_type}_{_ts}"
+                                / f"origin_{origin_idx}"
+                                / target
+                            )
                             # Track B — list-in-cell parquet (delivery)
                             # Skipped when skip_predictions_delivery=True to
                             # reduce peak memory.  Ensemble downstream will not
@@ -1465,6 +1474,17 @@ class ForecastingModelManager(ModelManager):
         ):
             try:
                 predictions = self._forecast_model_artifact(self.args.artifact_name)
+                if (
+                    self._prediction_format == "prediction_frame"
+                    and isinstance(predictions, dict)
+                ):
+                    _ts = self.configs.get("timestamp", "")
+                    for target, pf in predictions.items():
+                        pf.save(
+                            self._model_path.data_generated
+                            / f"predictions_{self.args.run_type}_{_ts}"
+                            / target
+                        )
                 context = ForecastingContext(
                     configs=self.configs,
                     model_path=self._model_path,


### PR DESCRIPTION
## Summary
- Wire permanent PredictionFrame persistence in sub-model evaluation and forecast paths so PredictionFrameEnsembleManager can discover numpy outputs at `data_generated/predictions_{run_type}_{ts}/...`
- Add `_get_generated_pf_prediction_paths()` to ModelPathManager for numpy directory discovery
- Write 12-section CIC for PredictionFrameEnsembleManager

## Test plan
- [x] 7 new tests for numpy directory discovery (filters, sorting, staging exclusion)
- [x] 4 new tests for PF persistence wiring (eval permanent save, staging cleanup, forecast save, stage still called)
- [x] 4 existing tests fixed to mock new PredictionFrame.save call
- [x] Full suite: 1347 passed, 0 failures
- [x] Lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)