### PR TITLE
fix: remove stale reconcile() kwargs (C-142)

### DIFF
--- a/tests/test_falsification_extraction_runtime.py
+++ b/tests/test_falsification_extraction_runtime.py
@@ -1,0 +1,90 @@
+"""
+Falsification audit 2: extraction runtime correctness (2026-05-30).
+
+Orthogonal to audit 1 (docs/test-imports/CIC staleness). This audit
+attacks runtime correctness of the extraction.
+
+Findings:
+  Q-3: Production reconciliation path broken — reconcile() no longer
+       accepts lr, max_iters, tol kwargs. Both ensemble managers crash
+       with TypeError when reconciliation is enabled.
+"""
+import ast
+import inspect
+import pathlib
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
+
+
+# ── Q-3: Production reconciliation call must match API ────────────────────────
+
+def test_q3_reconcile_callable_without_removed_kwargs():
+    """Q-3: ReconciliationModule.reconcile() must be callable without lr/max_iters/tol."""
+    from views_reporting.reconciliation import ReconciliationModule
+
+    sig = inspect.signature(ReconciliationModule.reconcile)
+    params = set(sig.parameters.keys()) - {"self"}
+
+    removed_kwargs = {"lr", "max_iters", "tol"}
+    present = removed_kwargs & params
+
+    assert not present, (
+        f"ReconciliationModule.reconcile() still accepts removed kwargs: {present}. "
+        f"These were stripped during extraction — production call sites must not pass them."
+    )
+
+    required = {
+        name for name, p in sig.parameters.items()
+        if name != "self" and p.default is inspect.Parameter.empty
+    }
+    assert not required, (
+        f"reconcile() has required (non-default) params: {required}. "
+        f"Production calls reconcile() with no arguments."
+    )
+
+
+def test_q3_ensemble_reconcile_call_matches_api():
+    """Q-3: ensemble.py reconcile() call must use only params that reconcile() accepts."""
+    from views_reporting.reconciliation import ReconciliationModule
+
+    sig = inspect.signature(ReconciliationModule.reconcile)
+    accepted = set(sig.parameters.keys()) - {"self"}
+
+    # Parse ensemble.py to find the reconcile() call and extract kwargs
+    ensemble_file = REPO_ROOT / "views_pipeline_core/managers/ensemble/ensemble.py"
+    source = ensemble_file.read_text()
+    tree = ast.parse(source)
+
+    for node in ast.walk(tree):
+        if (isinstance(node, ast.Call)
+                and isinstance(node.func, ast.Attribute)
+                and node.func.attr == "reconcile"):
+            call_kwargs = {kw.arg for kw in node.keywords if kw.arg is not None}
+            unexpected = call_kwargs - accepted
+            assert not unexpected, (
+                f"ensemble.py calls reconcile() with kwargs {unexpected} "
+                f"that are not in the current API. Accepted: {accepted}"
+            )
+
+
+def test_q3_df_ensemble_reconcile_call_matches_api():
+    """Q-3: dataframe_ensemble.py reconcile() call must use only params that reconcile() accepts."""
+    from views_reporting.reconciliation import ReconciliationModule
+
+    sig = inspect.signature(ReconciliationModule.reconcile)
+    accepted = set(sig.parameters.keys()) - {"self"}
+
+    df_ensemble_file = REPO_ROOT / "views_pipeline_core/managers/ensemble/dataframe_ensemble.py"
+    source = df_ensemble_file.read_text()
+    tree = ast.parse(source)
+
+    for node in ast.walk(tree):
+        if (isinstance(node, ast.Call)
+                and isinstance(node.func, ast.Attribute)
+                and node.func.attr == "reconcile"):
+            call_kwargs = {kw.arg for kw in node.keywords if kw.arg is not None}
+            unexpected = call_kwargs - accepted
+            assert not unexpected, (
+                f"dataframe_ensemble.py calls reconcile() with kwargs {unexpected} "
+                f"that are not in the current API. Accepted: {accepted}"
+            )

--- a/views_pipeline_core/managers/ensemble/dataframe_ensemble.py
+++ b/views_pipeline_core/managers/ensemble/dataframe_ensemble.py
@@ -908,7 +908,7 @@ class DataFrameEnsembleManager:
         reconciliation_manager = ReconciliationModule(
             c_dataset=latest_c_dataset, pg_dataset=latest_pg_dataset
         )
-        return reconciliation_manager.reconcile(lr=0.01, max_iters=500, tol=1e-6)
+        return reconciliation_manager.reconcile()
 
     def _load_c_dataset(
         self,

--- a/views_pipeline_core/managers/ensemble/ensemble.py
+++ b/views_pipeline_core/managers/ensemble/ensemble.py
@@ -734,7 +734,7 @@ class EnsembleManager(ForecastingModelManager):
         reconciliation_manager = ReconciliationModule(
             c_dataset=latest_c_dataset, pg_dataset=latest_pg_dataset
         )
-        return reconciliation_manager.reconcile(lr=0.01, max_iters=500, tol=1e-6)
+        return reconciliation_manager.reconcile()
 
     def _load_c_dataset(
         self, cm_model: str, c_dataframe: Optional[pd.DataFrame]


### PR DESCRIPTION
## Summary

- Remove `lr=0.01, max_iters=500, tol=1e-6` kwargs from `reconcile()` calls in both `EnsembleManager` and `DataFrameEnsembleManager`
- These kwargs were removed from `ReconciliationModule.reconcile()` during the views-reporting extraction but the call sites were not updated
- Without this fix, any production ensemble run with reconciliation enabled crashes with `TypeError` after hours of compute

## Test plan

- [x] `test_q3_reconcile_callable_without_removed_kwargs` — verifies reconcile() API doesn't accept the removed kwargs
- [x] `test_q3_ensemble_reconcile_call_matches_api` — AST-parses ensemble.py to verify call kwargs match API
- [x] `test_q3_df_ensemble_reconcile_call_matches_api` — AST-parses dataframe_ensemble.py to verify call kwargs match API
- [x] All 3 tests pass after fix
- [x] Full test suite: no regressions (18 pre-existing failures from issues #105/#106 only)

Closes #104

🤖 Generated with [Claude Code](https://claude.com/claude-code)