### PR TITLE
fix: update reconciliation test signatures and exception type (C-18, C-140)

### DIFF
--- a/tests/test_modules/test_reconciliation.py
+++ b/tests/test_modules/test_reconciliation.py
@@ -63,9 +63,6 @@ class TestReconcileCountryWorker:
             1,        # country_id
             1,        # time_id
             feature,  # feature (must include pred_ prefix)
-            0.01,     # lr
-            500,      # max_iters
-            1e-6,     # tol
             cm_df,    # c_subset
             pg_df,    # pg_subset
             "cpu",    # device_str
@@ -88,7 +85,7 @@ class TestReconcileCountryWorker:
         pg_df = _make_pg_dataframe(n_grids, n_times, n_samples, feature="ged_sb")
         cm_df = _make_cm_dataframe(n_times, n_samples, feature="ged_sb")
 
-        args = (1, 1, feature, 0.01, 500, 1e-6, cm_df, pg_df, "cpu")
+        args = (1, 1, feature, cm_df, pg_df, "cpu")
         _, _, _, tensor = ReconciliationModule._reconcile_country_worker(args)
 
         # Reconciled tensor should be (n_samples, n_grids) — same as grid input
@@ -104,7 +101,7 @@ class TestReconcileCountryWorker:
         pg_df = _make_pg_dataframe(n_grids, n_times, n_samples, feature="ged_sb")
         cm_df = _make_cm_dataframe(n_times, n_samples, feature="ged_sb")
 
-        args = (1, 1, feature, 0.01, 500, 1e-6, cm_df, pg_df, "cpu")
+        args = (1, 1, feature, cm_df, pg_df, "cpu")
         _, _, _, tensor = ReconciliationModule._reconcile_country_worker(args)
 
         assert tensor.device == torch.device("cpu"), (
@@ -119,7 +116,7 @@ class TestReconcileCountryWorker:
         pg_df = _make_pg_dataframe(n_grids, n_times, n_samples, feature="ged_sb")
         cm_df = _make_cm_dataframe(n_times, n_samples, feature="ged_sb")
 
-        args = (1, 1, feature, 0.01, 500, 1e-6, cm_df, pg_df, "cpu")
+        args = (1, 1, feature, cm_df, pg_df, "cpu")
         _, _, _, tensor = ReconciliationModule._reconcile_country_worker(args)
 
         assert not torch.isnan(tensor).any(), (

--- a/tests/test_modules/test_statistics.py
+++ b/tests/test_modules/test_statistics.py
@@ -564,7 +564,7 @@ class TestForecastReconciler:
         grid = torch.randn(100, 50)
         country = torch.randn(50)  # Wrong number of samples
         
-        with pytest.raises(AssertionError, match="Mismatch in sample count"):
+        with pytest.raises(ValueError, match="Mismatch in sample count"):
             reconciler_cpu.reconcile_forecast(grid, country)
 
     def test_reconcile_forecast_probabilistic_non_negative(self, reconciler_cpu):


### PR DESCRIPTION
## Summary

- `TestReconcileCountryWorker`: Update 4 tests from 9-tuple to 6-tuple args (removed `lr`, `max_iters`, `tol` which were stripped from `_reconcile_country_worker` during extraction)
- `test_reconcile_forecast_probabilistic_sample_count_mismatch`: Change expected exception from `AssertionError` to `ValueError` (views-reporting changed the raise type)

## Test plan

- [x] 4 TestReconcileCountryWorker tests now pass (were failing with `ValueError: too many values to unpack`)
- [x] sample_count_mismatch test now passes (was failing: got `ValueError` but expected `AssertionError`)
- [x] Falsification guards `test_s3` and `test_s5` pass
- [x] Lint clean

Closes #105

🤖 Generated with [Claude Code](https://claude.com/claude-code)