### PR TITLE
fix: guard test imports of removed packages with pytest.importorskip (C-137)

### DIFF
--- a/tests/test_modules/test_mapping_characterization.py
+++ b/tests/test_modules/test_mapping_characterization.py
@@ -5,19 +5,20 @@ shapefile I/O. Written BEFORE extraction to views-reporting so they
 validate behavior through the re-export shim post-move.
 """
 
-import matplotlib
-
-matplotlib.use("Agg")
-
-import geopandas
-import pandas as pd
-import plotly
-import pytest
-from shapely.geometry import box
 from unittest.mock import MagicMock, patch
+
+import pandas as pd
+import pytest
 
 from views_pipeline_core.data.handlers import _CDataset, _PGDataset
 from views_pipeline_core.modules.mapping import MappingModule
+
+matplotlib = pytest.importorskip("matplotlib")
+matplotlib.use("Agg")
+geopandas = pytest.importorskip("geopandas")
+plotly = pytest.importorskip("plotly")
+shapely = pytest.importorskip("shapely")
+box = shapely.geometry.box
 
 
 @pytest.fixture(autouse=True)

--- a/tests/test_modules/test_reconciliation.py
+++ b/tests/test_modules/test_reconciliation.py
@@ -9,15 +9,16 @@ class with no tests, enabling safe future modifications.
 """
 from concurrent.futures import Future
 from unittest.mock import MagicMock, patch
-import pytest
 
 import numpy as np
 import pandas as pd
-import torch
+import pytest
 
+from views_pipeline_core.data.handlers import _CDataset, _PGDataset
 from views_pipeline_core.modules.reconciliation import ReconciliationModule
 from views_pipeline_core.modules.statistics import ForecastReconciler
-from views_pipeline_core.data.handlers import _CDataset, _PGDataset
+
+torch = pytest.importorskip("torch")
 
 
 # ── Helpers ──────────────────────────────────────────────────────────────────

--- a/tests/test_modules/test_report.py
+++ b/tests/test_modules/test_report.py
@@ -1,8 +1,12 @@
-import pytest
-import pandas as pd
-import matplotlib.pyplot as plt
 from unittest.mock import patch
+
+import pandas as pd
+import pytest
+
 from views_pipeline_core.modules.reports import ReportModule
+
+matplotlib = pytest.importorskip("matplotlib")
+plt = matplotlib.pyplot
 
 
 class TestReportModuleInit:

--- a/tests/test_modules/test_statistics.py
+++ b/tests/test_modules/test_statistics.py
@@ -1,12 +1,15 @@
-import pytest
-import numpy as np
-import torch
 from io import StringIO
 from unittest.mock import patch
+
+import numpy as np
+import pytest
+
 from views_pipeline_core.modules.statistics import (
     PosteriorDistributionAnalyzer,
     ForecastReconciler,
 )
+
+torch = pytest.importorskip("torch")
 
 
 class TestPosteriorDistributionAnalyzer:

--- a/tests/test_modules/test_visualizations.py
+++ b/tests/test_modules/test_visualizations.py
@@ -5,20 +5,21 @@ These tests exercise the visualization classes with mocked datasets,
 breaking the zero-test-coverage barrier before extraction to views-reporting.
 Matplotlib backend is set to "Agg" (non-interactive) so no display is needed.
 """
-import matplotlib
-matplotlib.use("Agg")
+from unittest.mock import MagicMock, patch
 
-import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
 import pytest
-from unittest.mock import MagicMock, patch
 
+from views_pipeline_core.data.handlers import _CDataset, _PGDataset
 from views_pipeline_core.modules.visualizations import (
     HistoricalLineGraph,
     PlotDistribution,
 )
-from views_pipeline_core.data.handlers import _CDataset, _PGDataset
+
+matplotlib = pytest.importorskip("matplotlib")
+matplotlib.use("Agg")
+plt = matplotlib.pyplot
 
 
 # ── Helpers ──────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Replace bare `import torch`/`import matplotlib`/etc. with `pytest.importorskip()` in 5 test files
- Follows existing precedent in `test_geopandas_characterization.py`
- Tests skip gracefully in clean CI; pass normally when views-reporting is installed

## Affected files

| File | Guard added for |
|------|----------------|
| `test_reconciliation.py` | `torch` |
| `test_statistics.py` | `torch` |
| `test_mapping_characterization.py` | `matplotlib`, `geopandas`, `plotly`, `shapely` |
| `test_visualizations.py` | `matplotlib` |
| `test_report.py` | `matplotlib` |

## Test plan

- [x] All 5 `test_h1_no_removed_package_imports` falsification guards pass
- [x] 141 actual tests still pass (packages available via views-reporting)
- [x] Lint clean (no E402 errors)

Closes #106

🤖 Generated with [Claude Code](https://claude.com/claude-code)