### PR TITLE
fix: guard remaining test imports and add reconciliation pre-flight check (C-142, C-143)

### DIFF
--- a/tests/test_falsification_extraction_runtime.py
+++ b/tests/test_falsification_extraction_runtime.py
@@ -13,6 +13,10 @@ import ast
 import inspect
 import pathlib
 
+import pytest
+
+pytest.importorskip("views_reporting")
+
 REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
 
 

--- a/tests/test_utils/test_views_dataset.py
+++ b/tests/test_utils/test_views_dataset.py
@@ -2,7 +2,10 @@ import pytest
 import pandas as pd
 import numpy as np
 from views_pipeline_core.data.handlers import _ViewsDataset, PGMDataset, CMDataset
-from views_reporting.statistics import (
+
+pytest.importorskip("views_reporting")
+
+from views_reporting.statistics import (  # noqa: E402
     calculate_hdi,
     calculate_map,
 )

--- a/views_pipeline_core/modules/validation/core_config_sniffer.py
+++ b/views_pipeline_core/modules/validation/core_config_sniffer.py
@@ -307,6 +307,13 @@ class CoreConfigSniffer:
                 f"Supported: {sorted(SUPPORTED_RECONCILIATION_TYPES)}. "
                 f"Update SUPPORTED_RECONCILIATION_TYPES in core_config_sniffer.py when ready."
             )
+        import importlib.util
+        if importlib.util.find_spec("views_reporting") is None:
+            raise ImportError(
+                "CoreConfigSniffer: reconciliation is configured but views-reporting "
+                "is not installed. Reconciliation requires views-reporting. "
+                "Install it with: pip install -e /path/to/views-reporting"
+            )
         if recon == "pgm_cm_point":
             recon_with = self._c.get("reconcile_with")
             if not recon_with:


### PR DESCRIPTION
## Summary
- Add `pytest.importorskip("views_reporting")` to 2 test files that were missed by C-137
- Add `importlib.util.find_spec("views_reporting")` pre-flight check to `CoreConfigSniffer._check_reconciliation_config()` — fail fast at startup, not after hours of compute

## Files Changed
- `tests/test_utils/test_views_dataset.py` — module-level importorskip guard
- `tests/test_falsification_extraction_runtime.py` — module-level importorskip guard
- `views_pipeline_core/modules/validation/core_config_sniffer.py` — pre-flight import availability check

## Test plan
- [x] `ruff check` — clean
- [x] Full test suite: 1479 passed, 4 skipped, 6 xfailed
- [x] ReconciliationConfigValidation tests: 6 passed (pre-flight check doesn't fire when views-reporting IS installed)

Closes #127
Addresses #128

🤖 Generated with [Claude Code](https://claude.com/claude-code)