### PR TITLE
fix: add importorskip guards to 7 remaining test files (C-142)

### DIFF
--- a/tests/test_modules/test_mapping_characterization.py
+++ b/tests/test_modules/test_mapping_characterization.py
@@ -10,8 +10,10 @@ from unittest.mock import MagicMock, patch
 import pandas as pd
 import pytest
 
-from views_pipeline_core.data.handlers import _CDataset, _PGDataset
-from views_pipeline_core.modules.mapping import MappingModule
+pytest.importorskip("views_reporting")
+
+from views_pipeline_core.data.handlers import _CDataset, _PGDataset  # noqa: E402
+from views_pipeline_core.modules.mapping import MappingModule  # noqa: E402
 
 matplotlib = pytest.importorskip("matplotlib")
 matplotlib.use("Agg")

--- a/tests/test_modules/test_reconciliation.py
+++ b/tests/test_modules/test_reconciliation.py
@@ -14,9 +14,11 @@ import numpy as np
 import pandas as pd
 import pytest
 
-from views_pipeline_core.data.handlers import _CDataset, _PGDataset
-from views_pipeline_core.modules.reconciliation import ReconciliationModule
-from views_pipeline_core.modules.statistics import ForecastReconciler
+pytest.importorskip("views_reporting")
+
+from views_pipeline_core.data.handlers import _CDataset, _PGDataset  # noqa: E402
+from views_pipeline_core.modules.reconciliation import ReconciliationModule  # noqa: E402
+from views_pipeline_core.modules.statistics import ForecastReconciler  # noqa: E402
 
 torch = pytest.importorskip("torch")
 

--- a/tests/test_modules/test_report.py
+++ b/tests/test_modules/test_report.py
@@ -3,7 +3,9 @@ from unittest.mock import patch
 import pandas as pd
 import pytest
 
-from views_pipeline_core.modules.reports import ReportModule
+pytest.importorskip("views_reporting")
+
+from views_pipeline_core.modules.reports import ReportModule  # noqa: E402
 
 matplotlib = pytest.importorskip("matplotlib")
 plt = matplotlib.pyplot

--- a/tests/test_modules/test_reports_utils.py
+++ b/tests/test_modules/test_reports_utils.py
@@ -1,7 +1,10 @@
 import pytest
 import pandas as pd
 from unittest.mock import patch
-from views_pipeline_core.modules.reports import (
+
+pytest.importorskip("views_reporting")
+
+from views_pipeline_core.modules.reports import (  # noqa: E402
     search_for_item_name,
     filter_metrics_by_eval_type_and_metrics,
 )

--- a/tests/test_modules/test_statistics.py
+++ b/tests/test_modules/test_statistics.py
@@ -4,7 +4,9 @@ from unittest.mock import patch
 import numpy as np
 import pytest
 
-from views_pipeline_core.modules.statistics import (
+pytest.importorskip("views_reporting")
+
+from views_pipeline_core.modules.statistics import (  # noqa: E402
     PosteriorDistributionAnalyzer,
     ForecastReconciler,
 )

--- a/tests/test_modules/test_transformations.py
+++ b/tests/test_modules/test_transformations.py
@@ -2,8 +2,11 @@ import pytest
 import pandas as pd
 import numpy as np
 import polars as pl
-from views_pipeline_core.modules.transformations import DatasetTransformationModule
-from views_pipeline_core.data.handlers import CMDataset
+
+pytest.importorskip("views_reporting")
+
+from views_pipeline_core.modules.transformations import DatasetTransformationModule  # noqa: E402
+from views_pipeline_core.data.handlers import CMDataset  # noqa: E402
 
 
 # ============================================================

--- a/tests/test_modules/test_visualizations.py
+++ b/tests/test_modules/test_visualizations.py
@@ -11,8 +11,10 @@ import numpy as np
 import pandas as pd
 import pytest
 
-from views_pipeline_core.data.handlers import _CDataset, _PGDataset
-from views_pipeline_core.modules.visualizations import (
+pytest.importorskip("views_reporting")
+
+from views_pipeline_core.data.handlers import _CDataset, _PGDataset  # noqa: E402
+from views_pipeline_core.modules.visualizations import (  # noqa: E402
     HistoricalLineGraph,
     PlotDistribution,
 )


### PR DESCRIPTION
## Summary
- 7 test files in `tests/test_modules/` import from extracted shim modules (mapping, reconciliation, reports, statistics, transformations, visualizations)
- These shims raise `ImportError` when views-reporting is not installed
- CI (which lacks views-reporting) fails with collection errors instead of skipping
- Added `pytest.importorskip("views_reporting")` guard to each file

PR #129 fixed 2 files; this fixes the remaining 7 that the CI log revealed.

## Files changed
- `test_mapping_characterization.py`
- `test_reconciliation.py`
- `test_report.py`
- `test_reports_utils.py`
- `test_statistics.py`
- `test_transformations.py`
- `test_visualizations.py`

## Test plan
- [x] `ruff check` clean
- [x] `pytest` — 1479 passed, 4 skipped, 6 xfailed

🤖 Generated with [Claude Code](https://claude.com/claude-code)