### PR TITLE
fix: complete CI guard coverage and reorder reconciliation pre-flight (C-142)

### DIFF
--- a/tests/test_falsification_biggest_risks_found.py
+++ b/tests/test_falsification_biggest_risks_found.py
@@ -159,6 +159,7 @@ def test_falsify_06_reconciliation_max_workers_ignored():
 
     Expected: ProcessPoolExecutor receives the computed max_workers value.
     """
+    pytest.importorskip("views_reporting")
     from pathlib import Path
     import ast
 

--- a/tests/test_falsification_pr1_extraction.py
+++ b/tests/test_falsification_pr1_extraction.py
@@ -5,8 +5,11 @@ Generated: 2026-05-28
 These tests encode findings. Each currently FAILS, documenting a real issue.
 Fix the underlying issue, then the test passes.
 """
+import pytest
 
-from pathlib import Path
+pytest.importorskip("views_reporting")
+
+from pathlib import Path  # noqa: E402
 
 # ---------------------------------------------------------------------------
 # F-1 (HARD): Test file imports bypass the shim

--- a/tests/test_falsification_pr1_extraction.py
+++ b/tests/test_falsification_pr1_extraction.py
@@ -9,7 +9,7 @@ import pytest
 
 pytest.importorskip("views_reporting")
 
-from pathlib import Path  # noqa: E402
+from pathlib import Path
 
 # ---------------------------------------------------------------------------
 # F-1 (HARD): Test file imports bypass the shim

--- a/tests/test_managers/test_reporting_stage.py
+++ b/tests/test_managers/test_reporting_stage.py
@@ -15,6 +15,8 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+pytest.importorskip("views_reporting")
+
 sys.modules["wandb"] = MagicMock()
 sys.modules["views_evaluation"] = MagicMock()
 sys.modules["views_evaluation.evaluation"] = MagicMock()

--- a/tests/test_modules/test_core_config_sniffer.py
+++ b/tests/test_modules/test_core_config_sniffer.py
@@ -412,6 +412,7 @@ class TestReconciliationConfigValidation:
         CoreConfigSniffer(configs, _valid_partition(), target="model").sniff_all("calibration")
 
     def test_pgm_cm_point_with_reconcile_with_passes(self):
+        pytest.importorskip("views_reporting")
         configs = {
             **_valid_configs(),
             "reconciliation": "pgm_cm_point",
@@ -542,6 +543,7 @@ class TestEnsembleConfigValidation:
         CoreConfigSniffer(configs, {}, target="ensemble").sniff_all("forecasting")
 
     def test_ensemble_with_reconciliation_passes(self):
+        pytest.importorskip("views_reporting")
         configs = {
             **_valid_ensemble_configs(),
             "reconciliation": "pgm_cm_point",

--- a/views_pipeline_core/modules/validation/core_config_sniffer.py
+++ b/views_pipeline_core/modules/validation/core_config_sniffer.py
@@ -307,13 +307,6 @@ class CoreConfigSniffer:
                 f"Supported: {sorted(SUPPORTED_RECONCILIATION_TYPES)}. "
                 f"Update SUPPORTED_RECONCILIATION_TYPES in core_config_sniffer.py when ready."
             )
-        import importlib.util
-        if importlib.util.find_spec("views_reporting") is None:
-            raise ImportError(
-                "CoreConfigSniffer: reconciliation is configured but views-reporting "
-                "is not installed. Reconciliation requires views-reporting. "
-                "Install it with: pip install -e /path/to/views-reporting"
-            )
         if recon == "pgm_cm_point":
             recon_with = self._c.get("reconcile_with")
             if not recon_with:
@@ -322,6 +315,13 @@ class CoreConfigSniffer:
                     "'reconcile_with' to specify the CM model for reconciliation. "
                     "Add reconcile_with to config_meta.py."
                 )
+        import importlib.util
+        if importlib.util.find_spec("views_reporting") is None:
+            raise ImportError(
+                "CoreConfigSniffer: reconciliation is configured but views-reporting "
+                "is not installed. Reconciliation requires views-reporting. "
+                "Install it with: pip install -e /path/to/views-reporting"
+            )
 
     def _check_evaluation_contract(self, run_type: str) -> None:
         if run_type not in self._partition_dict:


### PR DESCRIPTION
## Summary
Fixes remaining 12 CI test failures on PR #103:

**Category 1 — Pre-flight check too aggressive:**
- Reordered `_check_reconciliation_config()` so config key validation runs BEFORE
  the `importlib.util.find_spec("views_reporting")` check. This lets tests that
  verify config errors (missing reconcile_with) pass without views-reporting.
- Added per-test `pytest.importorskip("views_reporting")` to reconciliation
  happy-path tests that can only pass with views-reporting installed.

**Category 2 — Missing importorskip guards:**
- `test_reporting_stage.py` — imports ReportingStage which depends on views-reporting
- `test_falsification_biggest_risks_found.py` — function-level import of views_reporting
- `test_falsification_pr1_extraction.py` — checks file paths that only exist with views-reporting

## Test plan
- [x] `ruff check` clean
- [x] `pytest` — 1479 passed, 4 skipped, 6 xfailed (with views-reporting)
- [ ] CI passes (without views-reporting) — tests skip gracefully

🤖 Generated with [Claude Code](https://claude.com/claude-code)