### PR TITLE
feat: pass prediction_format through ReportingContext to ForecastReportTemplate

### DIFF
--- a/tests/test_managers/test_reporting_stage.py
+++ b/tests/test_managers/test_reporting_stage.py
@@ -238,6 +238,91 @@ class TestForecastReportErrors:
             stage.generate_forecast_report(ctx)
 
 
+# ── GREEN: Forecast report — PredictionFrame path ─────────────────────────
+
+
+class TestForecastReportPredictionFrame:
+    """Verify forecast report generation for PredictionFrame models."""
+
+    @patch("views_pipeline_core.files.utils.read_dataframe")
+    @patch(
+        "views_reporting.templates.reports.forecast.ForecastReportTemplate"
+    )
+    def test_pf_path_passes_prediction_format_and_path(
+        self, mock_template_cls, mock_read,
+    ):
+        """PF path: template.generate() receives prediction_format and prediction_path."""
+        import pandas as pd
+
+        stage = _make_stage()
+        ctx = _make_context(prediction_format="prediction_frame")
+        ctx.model_path.target = "model"
+        ctx.model_path._get_generated_pf_prediction_paths.return_value = [
+            Path("/tmp/predictions_forecasting_20260601")
+        ]
+
+        mock_read.return_value = pd.DataFrame({"lr_sb": [0.1]})
+        mock_template_cls.return_value.generate.return_value = Path(
+            "/tmp/report.html"
+        )
+
+        result = stage.generate_forecast_report(ctx)
+
+        assert result == Path("/tmp/report.html")
+        mock_read.assert_called_once()  # historical only — PF path skips read_dataframe for forecast
+        mock_template_cls.return_value.generate.assert_called_once_with(
+            historical_dataframe=mock_read.return_value,
+            prediction_format="prediction_frame",
+            prediction_path=Path("/tmp/predictions_forecasting_20260601"),
+        )
+
+    @patch("views_pipeline_core.files.utils.read_dataframe")
+    @patch(
+        "views_reporting.templates.reports.forecast.ForecastReportTemplate"
+    )
+    def test_pf_path_missing_predictions_raises_file_not_found(
+        self, mock_template_cls, mock_read,
+    ):
+        """PF path: missing prediction directory raises FileNotFoundError."""
+        import pandas as pd
+
+        stage = _make_stage()
+        ctx = _make_context(prediction_format="prediction_frame")
+        ctx.model_path.target = "model"
+        ctx.model_path._get_generated_pf_prediction_paths.return_value = []
+
+        mock_read.return_value = pd.DataFrame({"lr_sb": [0.1]})
+
+        with pytest.raises(FileNotFoundError, match="PredictionFrame"):
+            stage.generate_forecast_report(ctx)
+
+    @patch("views_pipeline_core.files.utils.read_dataframe")
+    @patch(
+        "views_reporting.templates.reports.forecast.ForecastReportTemplate"
+    )
+    def test_df_path_unchanged_with_default_format(
+        self, mock_template_cls, mock_read,
+    ):
+        """Default prediction_format='dataframe' takes the existing parquet path."""
+        import pandas as pd
+
+        stage = _make_stage()
+        ctx = _make_context()  # default prediction_format="dataframe"
+        ctx.model_path.target = "model"
+
+        mock_read.return_value = pd.DataFrame({"lr_sb": [0.1]})
+        mock_template_cls.return_value.generate.return_value = Path(
+            "/tmp/report.html"
+        )
+
+        stage.generate_forecast_report(ctx)
+
+        mock_template_cls.return_value.generate.assert_called_once_with(
+            forecast_dataframe=mock_read.return_value,
+            historical_dataframe=mock_read.return_value,
+        )
+
+
 # ── GREEN: Evaluation report ────────────────────────────────────────────────
 
 

--- a/views_pipeline_core/managers/ensemble/dataframe_ensemble.py
+++ b/views_pipeline_core/managers/ensemble/dataframe_ensemble.py
@@ -443,6 +443,7 @@ class DataFrameEnsembleManager:
                     model_path=self._ensemble_path,
                     run_type=ctx.run_type,
                     entity=self._entity,
+                    prediction_format=ctx.prediction_format,
                 )
                 self._reporting_stage.generate_forecast_report(reporting_ctx)
             except PipelineException:
@@ -470,6 +471,7 @@ class DataFrameEnsembleManager:
                     model_path=self._ensemble_path,
                     run_type=ctx.run_type,
                     entity=self._entity,
+                    prediction_format=ctx.prediction_format,
                 )
                 self._reporting_stage.generate_evaluation_report(reporting_ctx)
             except PipelineException:

--- a/views_pipeline_core/managers/ensemble/prediction_frame_ensemble.py
+++ b/views_pipeline_core/managers/ensemble/prediction_frame_ensemble.py
@@ -389,6 +389,7 @@ class PredictionFrameEnsembleManager:
                     model_path=self._ensemble_path,
                     run_type=ctx.run_type,
                     entity=self._entity,
+                    prediction_format=ctx.prediction_format,
                 )
                 self._reporting_stage.generate_forecast_report(reporting_ctx)
             except PipelineException:
@@ -416,6 +417,7 @@ class PredictionFrameEnsembleManager:
                     model_path=self._ensemble_path,
                     run_type=ctx.run_type,
                     entity=self._entity,
+                    prediction_format=ctx.prediction_format,
                 )
                 self._reporting_stage.generate_evaluation_report(reporting_ctx)
             except PipelineException:

--- a/views_pipeline_core/managers/model/model.py
+++ b/views_pipeline_core/managers/model/model.py
@@ -1626,6 +1626,7 @@ class ForecastingModelManager(ModelManager):
                     model_path=self._model_path,
                     run_type=self.args.run_type,
                     entity=self._entity,
+                    prediction_format=self._prediction_format,
                 )
                 self._reporting_stage.generate_forecast_report(context)
             except PipelineException:
@@ -1954,6 +1955,7 @@ class ForecastingModelManager(ModelManager):
                     model_path=self._model_path,
                     run_type=self.args.run_type,
                     entity=self._entity,
+                    prediction_format=self._prediction_format,
                 )
                 self._reporting_stage.generate_evaluation_report(context)
             except PipelineException:

--- a/views_pipeline_core/managers/reporting/stage.py
+++ b/views_pipeline_core/managers/reporting/stage.py
@@ -28,6 +28,7 @@ class ReportingContext(BaseStageContext):
     reporting-specific fields.
     """
     entity: str  # WandB entity for get_latest_run(), e.g. "views_pipeline"
+    prediction_format: str = "dataframe"
 
 
 class ReportingStage:
@@ -59,8 +60,6 @@ class ReportingStage:
             FileNotFoundError: If forecast dataframe is not found.
             ValueError: If model_path.target is not 'model' or 'ensemble'.
         """
-        from views_pipeline_core.files.utils import read_dataframe
-
         logger.info(
             f"Generating forecast report for "
             f"{context.model_path.target} {context.configs['name']}..."
@@ -68,21 +67,6 @@ class ReportingStage:
 
         # --- Load historical data ---
         historical_df = self._load_historical_data(context)
-
-        # --- Load forecast data ---
-        try:
-            forecast_df = read_dataframe(
-                context.model_path._get_generated_predictions_data_file_paths(
-                    run_type=context.run_type
-                )[0]
-            )
-            logger.info("Using latest forecast dataframe")
-        except (FileNotFoundError, IndexError) as e:
-            raise FileNotFoundError(
-                f"Forecast dataframe was probably not found. Please run the "
-                f"pipeline in forecasting mode with '--run_type forecasting' "
-                f"to generate the forecast dataframe. More info: {e}"
-            ) from e
 
         # --- Generate report ---
         from views_reporting.templates.reports.forecast import (
@@ -94,10 +78,46 @@ class ReportingStage:
             model_path=context.model_path,
             run_type=context.run_type,
         )
-        report_path = forecast_template.generate(
-            forecast_dataframe=forecast_df,
-            historical_dataframe=historical_df,
-        )
+
+        if context.prediction_format == "prediction_frame":
+            try:
+                prediction_path = (
+                    context.model_path._get_generated_pf_prediction_paths(
+                        run_type=context.run_type
+                    )[0]
+                )
+            except (FileNotFoundError, IndexError) as e:
+                raise FileNotFoundError(
+                    f"No PredictionFrame prediction directory found. Run the "
+                    f"pipeline in forecasting mode with '--run_type forecasting' "
+                    f"to generate predictions. More info: {e}"
+                ) from e
+            logger.info("Using PredictionFrame predictions from %s", prediction_path)
+            report_path = forecast_template.generate(
+                historical_dataframe=historical_df,
+                prediction_format="prediction_frame",
+                prediction_path=prediction_path,
+            )
+        else:
+            from views_pipeline_core.files.utils import read_dataframe
+
+            try:
+                forecast_df = read_dataframe(
+                    context.model_path._get_generated_predictions_data_file_paths(
+                        run_type=context.run_type
+                    )[0]
+                )
+                logger.info("Using latest forecast dataframe")
+            except (FileNotFoundError, IndexError) as e:
+                raise FileNotFoundError(
+                    f"Forecast dataframe was probably not found. Please run the "
+                    f"pipeline in forecasting mode with '--run_type forecasting' "
+                    f"to generate the forecast dataframe. More info: {e}"
+                ) from e
+            report_path = forecast_template.generate(
+                forecast_dataframe=forecast_df,
+                historical_dataframe=historical_df,
+            )
 
         self._wandb_module.send_alert(
             title="Forecast Report Generated",


### PR DESCRIPTION
## Summary

- Adds `prediction_format: str = "dataframe"` field to `ReportingContext`
- Updates `ReportingStage.generate_forecast_report()` to dispatch between parquet (DataFrame) and numpy (PredictionFrame) loading based on format
- Forwards `prediction_format` from all 6 `ReportingContext(...)` instantiation sites (model.py ×2, dataframe_ensemble.py ×2, prediction_frame_ensemble.py ×2)
- Adds 3 tests: PF path passes correct args to template, missing PF dir raises `FileNotFoundError`, DF path unchanged with default format

Pairs with views-reporting PR #68 which added `prediction_format` + `prediction_path` parameters to `ForecastReportTemplate.generate()`. Closes views-reporting#64.

## Test plan

- [x] All 14 reporting stage tests pass (3 new + 11 existing)
- [x] Full suite: 1481 passed, 0 new failures
- [x] Lint clean (`ruff check` on all 5 changed files)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)