### PR TITLE
feat: provenance-aware get_run_by_timestamp lookup (#178, core half)

### DIFF
--- a/tests/test_utils/test_wandb_utils.py
+++ b/tests/test_utils/test_wandb_utils.py
@@ -469,3 +469,15 @@ class TestGetRunByTimestamp:
 
         with pytest.raises(ConnectionError):
             get_run_by_timestamp("entity", "model", "train", "20240101_010101")
+
+    @pytest.mark.parametrize("bad_ts", ["", None])
+    @patch('wandb.Api')
+    def test_raises_on_empty_timestamp(self, mock_api, bad_ts):
+        """A blank timestamp is a caller error -> ValueError, not a silent mismatch.
+
+        Without the guard, `config.get("timestamp") == None` would match a run
+        whose config carries no timestamp, returning a non-provenance-matched run.
+        """
+        with pytest.raises(ValueError):
+            get_run_by_timestamp("entity", "model", "train", bad_ts)
+        mock_api.return_value.runs.assert_not_called()

--- a/tests/test_utils/test_wandb_utils.py
+++ b/tests/test_utils/test_wandb_utils.py
@@ -15,6 +15,7 @@ from views_pipeline_core.modules.wandb.utils import (
     format_evaluation_dict,
     format_metadata_dict,
     get_latest_run,
+    get_run_by_timestamp,
 )
 
 
@@ -394,3 +395,77 @@ class TestGetLatestRun:
 
         with pytest.raises(ValueError):
             get_latest_run("entity", "model", "train")
+
+
+class TestGetRunByTimestamp:
+    """Provenance-aware lookup: select the run that produced a specific artifact
+    by matching its pipeline timestamp (issue #178)."""
+
+    @staticmethod
+    def _run(state, created_at, summary, config):
+        r = Mock()
+        r.state = state
+        r.created_at = created_at
+        r.summary = summary
+        r.config = config
+        return r
+
+    @patch('wandb.Api')
+    def test_returns_run_matching_timestamp_not_newest(self, mock_api):
+        """Must return the run whose config timestamp matches — not the newest run."""
+        older_match = self._run(
+            "finished", "2024-01-01",
+            {"metric": 0.7, "another": 0.4}, {"timestamp": "20240101_010101"},
+        )
+        newer_other = self._run(
+            "finished", "2024-01-02",
+            {"metric": 0.5, "another": 0.3}, {"timestamp": "20240102_020202"},
+        )
+        mock_api.return_value.runs.return_value = [older_match, newer_other]
+
+        result = get_run_by_timestamp("entity", "model", "train", "20240101_010101")
+
+        assert result is older_match
+
+    @patch('wandb.Api')
+    def test_returns_none_when_no_run_matches_timestamp(self, mock_api):
+        """No qualifying run carries the requested timestamp -> None (caller falls back)."""
+        run = self._run(
+            "finished", "2024-01-02",
+            {"metric": 0.5, "another": 0.3}, {"timestamp": "20240102_020202"},
+        )
+        mock_api.return_value.runs.return_value = [run]
+
+        assert get_run_by_timestamp("entity", "model", "train", "19990101_000000") is None
+
+    @patch('wandb.Api')
+    def test_skips_non_qualifying_runs_even_if_timestamp_matches(self, mock_api):
+        """A failed or empty-summary run is not returned even if its timestamp matches."""
+        failed = self._run(
+            "failed", "2024-01-02",
+            {"metric": 0.5, "another": 0.3}, {"timestamp": "20240101_010101"},
+        )
+        empty = self._run(
+            "finished", "2024-01-03",
+            {"only_one": 0.5}, {"timestamp": "20240101_010101"},
+        )
+        mock_api.return_value.runs.return_value = [failed, empty]
+
+        assert get_run_by_timestamp("entity", "model", "train", "20240101_010101") is None
+
+    @patch('wandb.Api')
+    def test_returns_none_when_project_not_found(self, mock_api):
+        """Project absent (offline-only model) -> None, inherits the #177 contract."""
+        mock_api.return_value.runs.side_effect = ValueError(
+            "Could not find project 'entity/model_train'"
+        )
+
+        assert get_run_by_timestamp("entity", "model", "train", "20240101_010101") is None
+
+    @patch('wandb.Api')
+    def test_propagates_transient_api_error(self, mock_api):
+        """Transient errors propagate (distinguishable from 'no match'), inherits #177."""
+        mock_api.return_value.runs.side_effect = ConnectionError("wandb unreachable")
+
+        with pytest.raises(ConnectionError):
+            get_run_by_timestamp("entity", "model", "train", "20240101_010101")

--- a/views_pipeline_core/modules/wandb/__init__.py
+++ b/views_pipeline_core/modules/wandb/__init__.py
@@ -11,4 +11,5 @@ from .utils import (
     format_evaluation_dict as format_evaluation_dict,
     format_metadata_dict as format_metadata_dict,
     get_latest_run as get_latest_run,
+    get_run_by_timestamp as get_run_by_timestamp,
 )

--- a/views_pipeline_core/modules/wandb/utils.py
+++ b/views_pipeline_core/modules/wandb/utils.py
@@ -364,6 +364,57 @@ def format_metadata_dict(metadata_dict):
 _PROJECT_NOT_FOUND_MARKER = "could not find project"
 
 
+def _fetch_qualifying_runs(
+    entity: str, model_name: str, run_type: str
+) -> list:
+    """
+    Return the finished, metrics-bearing runs for a model's WandB project,
+    newest first.
+
+    Shared fetch + filter for :func:`get_latest_run` and
+    :func:`get_run_by_timestamp` (keeps the fragile project-not-found handling
+    in one place — see C-179). A run "qualifies" when its state is ``"finished"``
+    and its summary carries more than one key (i.e. it holds metrics).
+
+    Returns an empty list when the project does not exist (the normal case for
+    models run with ``WANDB_MODE=offline``). Transient WandB/API errors are
+    propagated unchanged so callers can distinguish "not in the cloud" from
+    "WandB hiccupped".
+    """
+    from wandb import Api
+
+    project_path = f"{entity}/{model_name}_{run_type}"
+    api = Api()
+    try:
+        wandb_runs = sorted(
+            api.runs(project_path, include_sweeps=False),
+            key=lambda run: run.created_at,
+            reverse=True,
+        )
+    except ValueError as e:
+        # WandB raises ValueError("Could not find project ...") when the project
+        # does not exist — routine for offline-only models. Treat as "no run".
+        # Any other ValueError is unexpected and propagates (logged so a wandb
+        # message-text change that breaks the match above is observable — C-179).
+        if _PROJECT_NOT_FOUND_MARKER in str(e).lower():
+            logger.info(
+                f"WandB project '{project_path}' not found; treating as no run "
+                f"available (e.g. model run with WANDB_MODE=offline)."
+            )
+            return []
+        logger.warning(
+            f"Unexpected ValueError from WandB for '{project_path}' "
+            f"(not recognised as project-not-found): {e}. Re-raising."
+        )
+        raise
+
+    return [
+        run
+        for run in wandb_runs
+        if run.state == "finished" and len(dict(run.summary)) > 1
+    ]
+
+
 def get_latest_run(
     entity: str, model_name: str, run_type: str
 ) -> Optional['wandb.apis.public.runs.Run']:
@@ -394,45 +445,63 @@ def get_latest_run(
         Exception: Transient WandB/API errors are propagated. Project-not-found
             is NOT raised — it is reported as ``None``.
     """
-    from wandb import Api
-
-    project_path = f"{entity}/{model_name}_{run_type}"
-    api = Api()
-    try:
-        wandb_runs = sorted(
-            api.runs(project_path, include_sweeps=False),
-            key=lambda run: run.created_at,
-            reverse=True,
+    qualifying_runs = _fetch_qualifying_runs(entity, model_name, run_type)
+    if not qualifying_runs:
+        logger.info(
+            f"No finished, metrics-bearing WandB run found for "
+            f"'{entity}/{model_name}_{run_type}'."
         )
-    except ValueError as e:
-        # WandB raises ValueError("Could not find project ...") when the project
-        # does not exist — routine for offline-only models. Treat as "no run".
-        # Any other ValueError is unexpected and propagates (logged so a wandb
-        # message-text change that breaks the match above is observable — C-179).
-        if _PROJECT_NOT_FOUND_MARKER in str(e).lower():
-            logger.info(
-                f"WandB project '{project_path}' not found; treating as no run "
-                f"available (e.g. model run with WANDB_MODE=offline)."
-            )
-            return None
-        logger.warning(
-            f"Unexpected ValueError from WandB for '{project_path}' "
-            f"(not recognised as project-not-found): {e}. Re-raising."
-        )
-        raise
+        return None
+    return qualifying_runs[0]
 
-    # Pick the latest successfully finished run that carries metrics. Returns
-    # None (not StopIteration) when no run qualifies — this is a normal state.
-    latest_run = next(
+
+def get_run_by_timestamp(
+    entity: str, model_name: str, run_type: str, timestamp: str
+) -> Optional['wandb.apis.public.runs.Run']:
+    """
+    Retrieve the finished, metrics-bearing WandB run that produced a specific
+    artifact, identified by its pipeline ``timestamp``.
+
+    Provenance-aware counterpart to :func:`get_latest_run` (see GitHub issue
+    #178). The pipeline stamps a single ``timestamp`` (``YYYYMMDD_HHMMSS``,
+    created at ``configuration.py``) into *both* the artifact filename and the
+    WandB run's config (``config=self.configs`` in the model manager). This
+    function selects the run whose ``config["timestamp"]`` matches the artifact's
+    timestamp, so a report can attach the metrics of the run that actually
+    produced the artifact under report — not merely the newest run in the
+    project.
+
+    Contract:
+        Returns the newest qualifying run whose ``config["timestamp"] ==
+        timestamp``, or ``None`` when no qualifying run carries that timestamp
+        (project absent, no qualifying run, or none match). ``None`` means
+        "the artifact's run could not be identified" — a caller that needs a
+        best-effort display should fall back to :func:`get_latest_run` and
+        *label* the metrics as not provenance-matched, never silently present a
+        non-matching run's metrics as the artifact's.
+
+        Transient WandB/API errors are propagated (same posture as
+        :func:`get_latest_run`).
+
+    Returns:
+        Optional[wandb.Run]: The run whose config timestamp matches, or ``None``.
+
+    Raises:
+        Exception: Transient WandB/API errors are propagated. Project-not-found
+            is NOT raised — it is reported as ``None``.
+    """
+    qualifying_runs = _fetch_qualifying_runs(entity, model_name, run_type)
+    match = next(
         (
             run
-            for run in wandb_runs
-            if run.state == "finished" and len(dict(run.summary)) > 1
+            for run in qualifying_runs
+            if dict(run.config).get("timestamp") == timestamp
         ),
         None,
     )
-    if latest_run is None:
+    if match is None:
         logger.info(
-            f"No finished, metrics-bearing WandB run found for '{project_path}'."
+            f"No finished WandB run with config timestamp '{timestamp}' found "
+            f"for '{entity}/{model_name}_{run_type}'."
         )
-    return latest_run
+    return match

--- a/views_pipeline_core/modules/wandb/utils.py
+++ b/views_pipeline_core/modules/wandb/utils.py
@@ -487,9 +487,18 @@ def get_run_by_timestamp(
         Optional[wandb.Run]: The run whose config timestamp matches, or ``None``.
 
     Raises:
+        ValueError: If ``timestamp`` is empty/falsy. A blank timestamp is a
+            caller error, not a "no match" — without this guard it would
+            silently match a run whose config carries no timestamp
+            (``None == None``), returning a non-provenance-matched run.
         Exception: Transient WandB/API errors are propagated. Project-not-found
             is NOT raised — it is reported as ``None``.
     """
+    if not timestamp:
+        raise ValueError(
+            "get_run_by_timestamp requires a non-empty timestamp "
+            "(the artifact's YYYYMMDD_HHMMSS stamp)."
+        )
     qualifying_runs = _fetch_qualifying_runs(entity, model_name, run_type)
     match = next(
         (


### PR DESCRIPTION
Core-side half of #178. **Does not close #178** (the report wiring is a tandem views-reporting PR — see below).

## Problem
`get_latest_run` returns the *newest* run in a model's wandb project, but an evaluation report needs the run that produced the **specific artifact** under report. "Newest" can silently attach the wrong run's metrics.

## Key finding (investigation)
A join key already exists: the pipeline stamps one `timestamp` (`YYYYMMDD_HHMMSS`, set at `configuration.py:182`) into **both** the artifact filename **and** the wandb run config (`config=self.configs` at `model.py:1188/1256/1478`). So `wandb_run.config["timestamp"]` ↔ artifact-filename timestamp is a usable join. `get_latest_run` just never used it.

## Change (core only)
- **`get_run_by_timestamp(entity, model_name, run_type, timestamp)`** — returns the finished, metrics-bearing run whose `config["timestamp"]` matches, else `None`. `None` = "the artifact's run couldn't be identified"; a caller wanting best-effort display should fall back to `get_latest_run` and **label** the metrics as not-provenance-matched — never silently present a non-matching run's metrics as the artifact's (#178 acceptance criterion).
- **`_fetch_qualifying_runs` helper** — extracts the fetch + the fragile project-not-found marker logic (C-179) into **one** place, shared by both lookups, so a future wandb reword is a one-line fix. `get_latest_run` is refactored onto it with **behavior preserved** (its #177 tests pass unchanged).
- Exported from `modules/wandb/__init__.py`; new `TestGetRunByTimestamp` (match-not-newest, no-match→None, skips non-qualifying, project-not-found→None, transient propagates).

## Why this is shippable independently (not cross-repo paralysed)
The consumer (`views-reporting/.../evaluation.py`) imports `from views_pipeline_core.modules.wandb import get_run_by_timestamp` — the **safe** dependency direction (reporting→core, already declared). This PR adds a pure, tested primitive to a module reporting already imports; no new edge, no lockstep.

## Tandem follow-up (separate, views-reporting)
`evaluation.py` already extracts the artifact timestamp (`evaluation.py:540`) — switch it to call `get_run_by_timestamp` first, fall back to `get_latest_run` + the inexact label. To be opened against views-reporting #105/#107 alongside this so the primitive isn't left unwired.

## Out of scope
The reverse, **circular `core→reporting` coupling** (the real cross-repo paralysis) is a separate cleanup effort — findings captured (ready to register as C-182/C-183/D-32).

## Tests
- `tests/test_utils/test_wandb_utils.py`: 40 pass (5 new + #177 regression intact). Full suite `1571 passed`; only the 3 pre-existing unrelated `test_visualizations::TestCreateDropdownButtons` failures remain (local views-reporting version drift). Lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)