### PR TITLE
investigate(#181): report-stage OOM — root cause, durable-fix design, regression guard

### DIFF
--- a/documentation/post_mortems/2026-06-19_report_stage_oom_181.md
+++ b/documentation/post_mortems/2026-06-19_report_stage_oom_181.md
@@ -1,0 +1,97 @@
+# Investigation & durable-fix design — #181 report-stage host-RAM OOM
+
+**Date:** 2026-06-19  **Issue:** views-pipeline-core #181 (cross-ref views-hydranet C-116 / #124)
+**Status:** root cause measured; durable fix designed; no fix landed yet (per "investigate, then log").
+
+## 1. Observed failure
+`python main.py -r calibration -t -e -re` (HydraNet `violet_visitor`, 32 GB box) is OOM-killed
+(exit 137, ~16–20 GB) in the **post-eval report/publish tail**. Dropping `-re` → 2.4 GB, exit 0
+(~7× drop). Peak **scales with `n_posterior_samples`** (S=3 completes, S=8 OOMs), is
+wandb-mode-independent, and the model side is ruled out (the inverse-transform on the real
+forecast volume is ~0.4 GB). Trajectory: train/eval flat ~2.7 GB (GPU) → PF assembly ~9 GB →
+report tail ("Publishing pg_metadata" → "Processing features") **doubles 9 → ~18 GB in ~60 s → OOM**.
+
+## 2. Root cause — object-dtype representations at full grid×time scale (measured)
+The report path materializes the prediction and historical data as **pandas object-dtype
+DataFrames** — `pred_{target}` cells holding Python lists of S samples, and historical scalar cells
+each wrapped in a size-1 `np.array`. Object dtype is ~50–160× heavier per cell than the equivalent
+dense `float32` array, and the report does it over the **full grid × full time span**.
+
+Amplifications (file:line):
+| # | Stage | Where | Carries S? | Applies to |
+|---|-------|-------|-----------|-----------|
+| A | PF → **list-in-cell** DataFrame (`[list(row) for row in pf.y_pred]`) | `managers/prediction/prediction_frame_converter.py:73` | **yes** | forecast (~1.17M rows) |
+| B | dataset **densification** + per-cell `np.array(float32)` | `data/handlers.py:_preprocess_dataframe` (47-76), `_validate_prediction_structure` (210-247), `_init_dataframe` (103-104) | yes | forecast |
+| **H** | **scalar→per-cell `np.array` object-ification** of historical actuals | `data/handlers.py:_init_dataframe:136-152` (non-broadcast path) | no (S=1) | **historical (~10.5M rows)** |
+| C | float64 tensor + `np.stack` 2nd copy, then MAP `np.sort` over samples | `data/handlers.py:_prediction_to_tensor:457-486`, views-reporting `statistics/dataset_statistics.py:calculate_map` | yes | forecast |
+
+The two-part signature maps cleanly: **(H) historical object-ification is the S-independent ~9 GB
+base** (the full calibration span is ~324 months × 32 400 cells ≈ 10.5M cells — ~9× the forecast
+volume), and **(C) the MAP `np.sort` over the S-axis tensor is the doubling 9 → 18 GB** ("Processing
+features"). This is why peak scales with S even though the report is "post-collapse" — the collapse
+(MAP) is the step that first materializes the full-S tensor. `skip_predictions_delivery=True` does
+**not** gate this path (it gates only Track-B parquet, `model.py:1334-1342`); `-re` is an independent
+flag (`args.py:266`) so eval does not require the report.
+
+## 3. Measurement (synthetic micro-benchmark, `reports/investigations/report_stage_oom_181.py`)
+Quarter-PGM scale measured here (this box has ~6–12 GB free; full scale would OOM it too), per-row
+bytes extrapolated to full production volumes. tracemalloc captures Python-heap (object cells); RSS
+captures numpy. **Numbers are order-of-magnitude (small-scale RSS is noisy); the ratios are the point.**
+
+| Stage (1 target) | B/row | full forecast GB | full historical GB |
+|---|---:|---:|---:|
+| dense float32 baseline (per sample) | 4 | — | — |
+| A list-in-cell  (S=8) | ~385 | ~0.42 | (n/a) |
+| B densify+arrays (S=8) | ~364 | ~0.40 | (n/a) |
+| **H historical obj-ify (S=1)** | ~220 | (n/a) | **~2.2** |
+| C float64 tensor | ~32–63 | ~0.03 | ~0.3 |
+
+Each object stage is ~**50–160× the dense per-sample cost**. With `n_targets` (the real run has
+several) multiplying the forecast side, the historical base + forecast frames + the float64 tensor +
+MAP sort copy alive concurrently plausibly sums to the observed ~16–18 GB. **The dense numpy compute
+is small (C ≈ 0.03/0.3 GB); the cost is the object-dtype DataFrames** — exactly the "list-in-cell /
+object dtype is the non-scaler; dense arrays scale" thesis (`views-frames`, C-40/C-66).
+
+## 4. Durable fix design
+**Principle: the report must consume dense arrays, never rebuild object-dtype DataFrames over the
+full grid.** It needs point/MAP + a few quantiles for a *sample* of entities — not all S, not every
+cell, not pandas.
+
+### Durable (the views-frames / Cluster-A direction)
+- The report **receives a typed, collapsed array frame** (a collapsed `PredictionFrame` / the
+  anticipated `MetricFrame` from the `views-frames` README §4.2) — point estimate + selected
+  quantiles already reduced — instead of loading a full-S list-in-cell parquet and re-deriving.
+  Kills A, B, C at the source. This is the keystone-track fix; gated on `views-frames` existing.
+- Historical actuals likewise flow as a **dense (time × entity) float32 array** (or are loaded
+  column-pruned + chunked), never object-ified per cell. Kills H.
+
+### Standalone quick wins (no views-frames dependency; can land first, low risk)
+1. **float32 in `_prediction_to_tensor`** (drop hardcoded `np.float64` at `handlers.py:465`) — halves C. Smallest, safest.
+2. **Collapse-before-materialize** — reduce S to point + quantiles *before* building the dense
+   tensor / before `to_prediction_df`, so nothing downstream carries S. Removes the S-scaling.
+3. **Entity sampling for graphs** — the historical line graph needs a handful of entities, not all
+   ~32 400 cells; load/object-ify only the sampled subset. (Converges with views-reporting **C-26**,
+   the render-scale sibling.)
+4. **Lazy / skipped densification in the report path** — the report needs per-entity series, not a
+   dense grid; don't fill 10.5M zero cells just to render.
+5. **Decouple the report** — make `-re` opt-out so an eval pass is never gated by report RAM
+   (issue open-question 5); a 32 GB box can then always complete `-t -e`.
+
+### Ownership / sequencing
+- **pipeline-core:** the converter (A), `handlers.py` densify/object-ify/float64 (B, H, C), a
+  collapse-to-array API, the `-re` decoupling. **views-reporting:** `calculate_map`/templates
+  consuming the collapsed array, entity sampling (its C-26). The durable frame contract is **views-frames**.
+- **Recommended order:** quick wins 1+2 first (unblock 32 GB boxes now) → entity sampling (3) →
+  durable array-frame input via views-frames (kills the class). Relationship: **C-40, C-66** (same
+  list-in-cell mechanism), **C-182** (immutable frames), **C-165** (no abstractions), views-reporting **C-26**.
+
+## 5. Regression guard
+`tests/test_managers/test_report_stage_memory.py` — drives the amplification chain at reduced scale
+and asserts the object-dtype overhead ratio stays bounded, so a future regression (or the fix) is
+measured by the test, not by OOM-killing a box.
+
+## 6. Register (next step)
+Register #181 as **Cluster A's first observed-in-production member** — distinct locus from C-40
+(persistence) and views-reporting C-26 (render): the report-stage `_load_historical_data` +
+PF-list-in-cell + per-cell object-ification + float64-tensor OOM. Cross-ref C-40/C-66/C-182/C-26,
+views-frames, views-hydranet C-116/#124.

--- a/reports/investigations/report_stage_oom_181.py
+++ b/reports/investigations/report_stage_oom_181.py
@@ -1,0 +1,140 @@
+"""Synthetic micro-benchmark for GitHub issue #181 — line-isolate the report-stage
+host-RAM amplification chain WITHOUT a GPU/model/full repro.
+
+#181: `main.py -r calibration -t -e -re` OOM-killed (~16-20 GB) in the post-eval
+report tail; drops ~7x without `-re`; scales with n_posterior_samples (S). Model
+side ruled out. Suspected amplifications, each an object-dtype / dense blow-up:
+
+  FORECAST side (carries S):
+    A  PF.y_pred (N,S) float32  --to_prediction_df-->  list-in-cell object DataFrame
+    B  PGMDataset(pred_df)       densify + per-cell np.array(float32)
+    C  to_tensor()              float64 tensor (+ np.stack second copy), then MAP sort
+  HISTORICAL side (S=1, but ~324 calibration months x 32_400 cells ~= 10.5M cells):
+    H  read_dataframe(raw) scalar df --PGMDataset(scalar_df, broadcast_features=False)-->
+       every scalar cell becomes a size-1 np.array (object dtype)
+
+This box has limited RAM (~6 GB free), so we MEASURE at reduced scale (cells=8100,
+quarter-PGM) and EXTRAPOLATE per-row to full PGM forecast (32_400 x 36) and
+historical (32_400 x 324). tracemalloc captures Python-heap (object cells / lists);
+RSS captures numpy tensors. calculate_map is intentionally NOT run (it is a sort
+over C's tensor -> +~1x transient; reasoned, not measured, to keep runtime bounded).
+
+Run: conda run -n views_pipeline python -u reports/investigations/report_stage_oom_181.py
+"""
+from __future__ import annotations
+
+import gc
+import os
+import tracemalloc
+
+import numpy as np
+import pandas as pd
+import psutil
+
+from views_pipeline_core.data.prediction_frame import PredictionFrame
+from views_pipeline_core.managers.prediction.prediction_frame_converter import (
+    PredictionFrameConverter,
+)
+from views_pipeline_core.data.handlers import PGMDataset
+
+_proc = psutil.Process(os.getpid())
+
+PGM_CELLS = 180 * 180          # 32_400
+FORECAST_N = PGM_CELLS * 36    # forecast volume rows
+HIST_N = PGM_CELLS * 324       # full calibration historical rows (~10.5M)
+
+CELLS = 8100                   # quarter-PGM measured scale (linear-extrapolates)
+MONTHS = 12
+
+
+def rss_mb() -> float:
+    return _proc.memory_info().rss / (1024 ** 2)
+
+
+def _grid(n_units: int, months: int):
+    units = np.arange(n_units, dtype=np.int64)
+    times = np.arange(1, months + 1, dtype=np.int64)
+    return np.repeat(times, n_units), np.tile(units, months), n_units * months
+
+
+def _stage(label, fn):
+    gc.collect()
+    tracemalloc.start()
+    r0 = rss_mb()
+    out = fn()
+    heap_peak = tracemalloc.get_traced_memory()[1] / (1024 ** 2)
+    tracemalloc.stop()
+    gc.collect()
+    r1 = rss_mb()
+    print(f"    {label:<38} RSS+={r1 - r0:7.1f}MB  heap-peak={heap_peak:7.1f}MB  RSS={r1:7.0f}MB",
+          flush=True)
+    return out, max(r1 - r0, 0.0), heap_peak
+
+
+def forecast_chain(S: int):
+    print(f"\n  [FORECAST] cells={CELLS} months={MONTHS} S={S}  N={CELLS*MONTHS:,}", flush=True)
+    t, u, n = _grid(CELLS, MONTHS)
+    y = np.random.default_rng(0).random((n, S), dtype=np.float32)
+    pf = PredictionFrame(y_pred=y, identifiers={"time": t, "unit": u})
+    print(f"    dense y_pred (N,S) float32 = {y.nbytes/1024**2:7.1f}MB"
+          f"  ({y.nbytes/n:.1f} B/row)", flush=True)
+    conv = PredictionFrameConverter()
+
+    df, _, a_heap = _stage("A to_prediction_df (list-in-cell)", lambda: conv.to_prediction_df(pf, "t0"))
+    df.index = df.index.set_names(["month_id", "priogrid_id"])
+    ds, b_rss, b_heap = _stage("B PGMDataset(pred) densify+arrays", lambda: PGMDataset(df))
+    tensor, c_rss, _ = _stage("C to_tensor (float64)", ds.to_tensor)
+    if isinstance(tensor, np.ndarray):
+        print(f"      tensor {tensor.shape} {tensor.dtype} = {tensor.nbytes/1024**2:.1f}MB"
+              f"  (float32 -> {tensor.nbytes/2/1024**2:.1f}MB)", flush=True)
+    res = {"S": S, "n": n,
+           "A_listcell_Bpr": a_heap * 1024**2 / n,
+           "B_obj_Bpr": max(b_heap, b_rss) * 1024**2 / n,
+           "C_tensor_Bpr": c_rss * 1024**2 / n}
+    gc.collect()
+    return res
+
+
+def historical_object_ification():
+    """Scalar (actuals) df -> PGMDataset(broadcast_features=False): per-cell np.array bloat."""
+    print(f"\n  [HISTORICAL] scalar actuals, cells={CELLS} months={MONTHS}  N={CELLS*MONTHS:,}", flush=True)
+    t, u, n = _grid(CELLS, MONTHS)
+    idx = pd.MultiIndex.from_arrays([t, u], names=["month_id", "priogrid_id"])
+    sdf = pd.DataFrame({"sb_best": np.random.default_rng(1).random(n).astype(np.float64)}, index=idx)
+    print(f"    dense scalar df = {sdf.memory_usage(deep=True).sum()/1024**2:7.1f}MB"
+          f"  ({sdf.memory_usage(deep=True).sum()/n:.1f} B/row)", flush=True)
+    ds, h_rss, h_heap = _stage("H PGMDataset(scalar) obj-ify+densify",
+                               lambda: PGMDataset(sdf, targets=["sb_best"]))
+    res = {"H_obj_Bpr": max(h_heap, h_rss) * 1024**2 / n}
+    gc.collect()
+    return res
+
+
+def main():
+    print(f"RAM available: {psutil.virtual_memory().available/1024**3:.1f}GB  RSS={rss_mb():.0f}MB",
+          flush=True)
+    fc = [forecast_chain(S) for S in (1, 3, 8)]
+    hist = historical_object_ification()
+
+    print("\n" + "=" * 86)
+    print("PER-ROW BYTES (measured @ quarter-PGM)  ->  EXTRAPOLATED to full production scale")
+    print("=" * 86)
+    print(f"FORECAST volume  N = 32400 x 36  = {FORECAST_N:,} rows")
+    print(f"HISTORICAL volume N = 32400 x 324 = {HIST_N:,} rows (full calibration span)\n")
+    print(f"{'stage (1 target)':<34}{'B/row':>9}{'forecast GB':>14}{'historical GB':>16}")
+    for r in fc:
+        for k, name in (("A_listcell_Bpr", f"A list-in-cell  S={r['S']}"),
+                        ("B_obj_Bpr",      f"B densify+arr  S={r['S']}"),
+                        ("C_tensor_Bpr",   f"C tensor f64   S={r['S']}")):
+            bpr = r[k]
+            print(f"{name:<34}{bpr:>9.0f}{bpr*FORECAST_N/1024**3:>14.2f}{bpr*HIST_N/1024**3:>16.2f}")
+    bpr = hist["H_obj_Bpr"]
+    print(f"{'H hist obj-ify (S=1)':<34}{bpr:>9.0f}{bpr*FORECAST_N/1024**3:>14.2f}{bpr*HIST_N/1024**3:>16.2f}")
+    print("\nNotes: forecast stages carry S (scale with n_posterior_samples); H is S-independent")
+    print("and applies to the ~10.5M-row historical frame -> the S-independent base.")
+    print("calculate_map adds ~1x transient over C (np.sort copy). Full repro stays on the 32GB box.")
+    print("\nDone.", flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_managers/test_report_stage_memory.py
+++ b/tests/test_managers/test_report_stage_memory.py
@@ -1,0 +1,76 @@
+"""Characterization / regression guard for issue #181 (report-stage host-RAM OOM).
+
+The report path converts dense float32 predictions into an **object-dtype
+list-in-cell** DataFrame (`PredictionFrameConverter.to_prediction_df`), and wraps
+historical/forecast data in datasets whose per-cell `np.array` representation is
+the dominant driver of the ~16-18 GB OOM (see
+documentation/post_mortems/2026-06-19_report_stage_oom_181.md). The dense numpy
+compute is small; the cost is the object-dtype representation.
+
+This test pins that overhead so:
+  * a regression that makes it heavier fails loudly, and
+  * the durable fix (report consumes dense arrays / a collapsed frame, no
+    list-in-cell) ALSO trips it — a deliberate signal to update this guard when
+    the report stops round-tripping through object dtype.
+"""
+import tracemalloc
+
+import numpy as np
+
+from views_pipeline_core.data.prediction_frame import PredictionFrame
+from views_pipeline_core.managers.prediction.prediction_frame_converter import (
+    PredictionFrameConverter,
+)
+
+
+def _heap_peak(fn):
+    tracemalloc.start()
+    out = fn()
+    peak = tracemalloc.get_traced_memory()[1]
+    tracemalloc.stop()
+    return out, peak
+
+
+class TestReportStageListInCellOverhead:
+    """#181: the list-in-cell conversion is object-dtype and far heavier than dense."""
+
+    def _make_pf(self, n_units: int, months: int, s: int) -> PredictionFrame:
+        n = n_units * months
+        return PredictionFrame(
+            y_pred=np.zeros((n, s), dtype=np.float32),
+            identifiers={
+                "time": np.repeat(np.arange(months), n_units),
+                "unit": np.tile(np.arange(n_units), months),
+            },
+        )
+
+    def test_list_in_cell_is_object_dtype(self):
+        pf = self._make_pf(2000, 10, 8)
+        df = PredictionFrameConverter().to_prediction_df(pf, "t0")
+        # A dense/array-backed report input (the #181 durable fix) would NOT be object dtype.
+        assert df["pred_t0"].dtype == object
+
+    def test_list_in_cell_heap_dwarfs_dense_array(self):
+        pf = self._make_pf(2000, 10, 8)  # N=20_000, S=8 -> dense 640 KB
+        df, peak = _heap_peak(
+            lambda: PredictionFrameConverter().to_prediction_df(pf, "t0")
+        )
+        dense = pf.y_pred.nbytes
+        # Measured ~50-160x; assert a conservative floor of 8x. If this ever drops
+        # below the floor because the report moved to dense arrays, that is the
+        # #181 fix landing — update this guard rather than the production code.
+        assert peak > 8 * dense, (
+            f"list-in-cell heap peak {peak} not >> dense {dense} (ratio "
+            f"{peak / dense:.1f}x); the #181 OOM driver may have changed — see "
+            "documentation/post_mortems/2026-06-19_report_stage_oom_181.md"
+        )
+
+    def test_overhead_scales_with_sample_count(self):
+        """Peak grows with S — why #181 scales with n_posterior_samples."""
+        _, peak_s3 = _heap_peak(
+            lambda: PredictionFrameConverter().to_prediction_df(self._make_pf(2000, 10, 3), "t0")
+        )
+        _, peak_s8 = _heap_peak(
+            lambda: PredictionFrameConverter().to_prediction_df(self._make_pf(2000, 10, 8), "t0")
+        )
+        assert peak_s8 > peak_s3


### PR DESCRIPTION
Investigation of #181 (post-eval report tail OOM-kills runs, exit 137, ~16–18 GB). **Does not close #181** — this is the measured root cause + durable-fix design + a regression guard, not the fix itself.

## What it found (measured)
The OOM is dominated by **pandas object-dtype representations, not dense compute**:
- The report builds **object-dtype** DataFrames — list-in-cell `pred_{target}` (`prediction_frame_converter.py:73`) + per-cell `np.array` actuals (`handlers.py:_init_dataframe:136-152`) — over the **full grid × full timeline**: **~50–160× the dense float32 cost** (~200–650 B/row vs 4).
- Two-part signature: **~9 GB S-independent base** = historical scalar→object-ification over the full calibration span (~10.5M cells); **doubling 9→18 GB** = MAP `np.sort` over the full-S float64 tensor (`_prediction_to_tensor:457-486`). The collapse is what first materializes the full-S tensor → why it scales with `n_posterior_samples` despite being "post-collapse."
- **Dense numpy compute is small** (~0.03/0.3 GB); the float64 hardcode is a *secondary* contributor.

## Deliverables
- `reports/investigations/report_stage_oom_181.py` — synthetic micro-benchmark (runs without GPU/model; line-isolates per-row bytes, extrapolates to full scale).
- `documentation/post_mortems/2026-06-19_report_stage_oom_181.md` — root cause + durable fix design (report consumes a dense collapsed array-frame / `views-frames` `MetricFrame`; quick wins: float32 tensor, collapse-before-materialize, entity-sampling, lazy densify, `-re` decoupling) + ownership/sequencing.
- `tests/test_managers/test_report_stage_memory.py` — regression guard pinning the list-in-cell object-dtype overhead (3 tests, pass).

## ⚠️ Merge coupling
Pairs with **#182**, which registers **C-186** (the risk-register entry for #181) whose text references the post-mortem/probe/test files added here. **Merge this PR before or together with #182** so those references resolve on `development`.

## Notes
- No production code changed — investigation/doc/test only. Cluster A (Data-Contract Gap), the first observed-in-production member; cross-ref C-40/C-66/C-182, views-reporting C-26, views-hydranet C-116/#124.

🤖 Generated with [Claude Code](https://claude.com/claude-code)