### PR TITLE
S1 (#225) — raise views-frames floor to ^1.7 (MetricFrame substrate)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ views-transformation-library = "^2.7.2"
 art = "^6.4"
 polars = ">=1.34.0,<2.0.0"
 appwrite = ">=13.4.1,<14.0.0"
-views-frames = "^1.3"
+views-frames = "^1.7"
 
 [tool.pytest.ini_options]
 filterwarnings = ["ignore::DeprecationWarning", "ignore::RuntimeWarning", "ignore::UserWarning"]


### PR DESCRIPTION
**Story S1 of epic #224** (Evaluation-of-record / MetricFrame). Closes #225.

## What
One-line dependency-floor bump: `views-frames "^1.3" → "^1.7"` in `pyproject.toml`.

## Why
`EvaluationReport.to_metric_frame()` (used by S2/#226) is built on the views-frames MetricFrame substrate (`FrameMetadata` + `assert_frame_envelope`), which needs **views-frames ≥1.4**. Aligning the floor to the published **1.7.0** (already the installed/used version, e.g. by the reconciliation adapter) makes the substrate requirement explicit.

## Publish-last model (no git pins)
`views-evaluation` stays a **normal published range** — its `to_metric_frame` is consumed via the **editable development install** during integration; publishing is the final step (views-evaluation#23), not a prerequisite. No GitHub-branch pins. The MetricFrame tests added in S2/S3 will capability-skip where `to_metric_frame` is absent (PyPI-only CI), so this bump alone introduces no CI dependency on unpublished code.

## Verification
- Installed views-frames is 1.7.0 → satisfies `^1.7`.
- `ruff check .` clean; views-frames conformance + reconciliation-adapter + register-guard tests green.
- No code logic changed (pure version-floor bump).

## Acceptance criteria (from #225)
- [x] `views-frames` bumped to `^1.7`; `views-evaluation` remains a normal published range (no git source).
- [x] `to_metric_frame` imports in the dev env (views-frames ≥1.4 satisfied).
- [ ] CI green.