### PR TITLE
S1 (#234) — reconcile_frames: frames-native reconciliation module for the PredictionFrame path

### DIFF
--- a/tests/test_modules/test_reconcile_frames.py
+++ b/tests/test_modules/test_reconcile_frames.py
@@ -9,8 +9,6 @@ Covers the two functions in `modules/reconciliation/reconcile_frames.py`:
 Orchestration is checked with fakes (no geography needed); parity is checked with the real
 injected reconciler (geography map), mirroring the proven spike.
 """
-import logging
-
 import numpy as np
 import pytest
 from views_frames import FrameMetadata, PredictionFrame, SpatialLevel, SpatioTemporalIndex
@@ -147,14 +145,16 @@ def test_reconcile_frames_carries_metadata():
     assert out.metadata is not None and out.metadata.model == "rusty_sibling"
 
 
-def test_reconcile_frames_logs_mode(caplog):
+def test_reconcile_frames_logs_mode(monkeypatch):
+    # Verify the mode is logged by capturing the logger.info call directly — robust to any
+    # ambient logging config (caplog capture proved environment-fragile across CI).
+    import views_pipeline_core.modules.reconciliation.reconcile_frames as rf
+
+    captured: list[tuple] = []
+    monkeypatch.setattr(rf.logger, "info", lambda *args, **kwargs: captured.append(args))
     pgm, cm, _, _ = _build_case(times=[1], n_samples=4, cm_point=True, seed=4)
-    # Target the module logger explicitly: a bare at_level(INFO) does not lower this
-    # logger's effective level, so an ambient WARNING config (as in CI) would filter the
-    # INFO record before caplog sees it.
-    with caplog.at_level(logging.INFO, logger="views_pipeline_core.modules.reconciliation.reconcile_frames"):
-        reconcile_frames(_ReorderingReconciler(), cm, pgm)
-    assert any("mode=point-broadcast" in r.getMessage() for r in caplog.records)
+    reconcile_frames(_ReorderingReconciler(), cm, pgm)
+    assert any(POINT_BROADCAST in args for args in captured)
 
 
 # --------------------------------------------------------------------------- real substrate (parity)

--- a/tests/test_modules/test_reconcile_frames.py
+++ b/tests/test_modules/test_reconcile_frames.py
@@ -1,0 +1,212 @@
+"""#234 (epic #233) — the frames-native reconciliation orchestration.
+
+Covers the two functions in `modules/reconciliation/reconcile_frames.py`:
+  * `align_country_to_grid` — point-broadcast vs aligned-draws vs fail-loud.
+  * `reconcile_frames` — chunk-by-time, row realignment, no-mutation, metadata pass-through,
+    and (against the real `views_frames_reconcile` substrate) per-draw parity with country
+    totals + chunk==whole bit-exactness.
+
+Orchestration is checked with fakes (no geography needed); parity is checked with the real
+injected reconciler (geography map), mirroring the proven spike.
+"""
+import logging
+
+import numpy as np
+import pytest
+from views_frames import FrameMetadata, PredictionFrame, SpatialLevel, SpatioTemporalIndex
+
+from views_pipeline_core.modules.reconciliation.reconcile_frames import (
+    ALIGNED_DRAWS,
+    POINT_BROADCAST,
+    align_country_to_grid,
+    reconcile_frames,
+)
+
+# --------------------------------------------------------------------------- helpers
+
+
+def _pf(values, time, unit, level):
+    return PredictionFrame(
+        np.asarray(values, dtype=np.float32),
+        SpatioTemporalIndex(
+            np.asarray(time, dtype=np.int64),
+            np.asarray(unit, dtype=np.int64),
+            level,
+        ),
+    )
+
+
+# geography: country 1 <- grids 11,12 ; country 2 <- grids 21,22,23
+_GRIDS = {1: [11, 12], 2: [21, 22, 23]}
+
+
+def _build_case(times, n_samples, cm_point, seed=0):
+    """Build (pgm_frame, cm_frame, map_keys, map_vals) for the given times.
+
+    cm_point=True → cm has sample_count 1; else cm has `n_samples` draws.
+    """
+    rng = np.random.default_rng(seed)
+    grids = [g for gs in _GRIDS.values() for g in gs]
+    countries = sorted(_GRIDS)
+
+    pg_time = [t for t in times for _ in grids]
+    pg_unit = [g for _ in times for g in grids]
+    pgm = _pf(rng.uniform(0, 10, size=(len(pg_unit), n_samples)), pg_time, pg_unit, SpatialLevel.PGM)
+
+    cm_time = [t for t in times for _ in countries]
+    cm_unit = [c for _ in times for c in countries]
+    cm_cols = 1 if cm_point else n_samples
+    cm = _pf(rng.uniform(40, 120, size=(len(cm_unit), cm_cols)), cm_time, cm_unit, SpatialLevel.CM)
+
+    map_keys = np.array([[t, g] for t in times for g in grids], dtype=np.int64)
+    map_vals = np.array([_country_of(g) for _ in times for g in grids], dtype=np.int64)
+    return pgm, cm, map_keys, map_vals
+
+
+def _country_of(grid):
+    return next(c for c, gs in _GRIDS.items() if grid in gs)
+
+
+# --------------------------------------------------------------------------- align
+
+
+def test_align_point_broadcast_tiles_across_draws():
+    cm = _pf([[100.0], [50.0]], time=[1, 1], unit=[1, 2], level=SpatialLevel.CM)
+    aligned, mode = align_country_to_grid(cm, n_samples=4)
+    assert mode == POINT_BROADCAST
+    assert aligned.sample_count == 4
+    np.testing.assert_array_equal(aligned.values, np.array([[100] * 4, [50] * 4], dtype=np.float32))
+
+
+def test_align_aligned_draws_passthrough():
+    cm = _pf(np.ones((2, 8)), time=[1, 1], unit=[1, 2], level=SpatialLevel.CM)
+    aligned, mode = align_country_to_grid(cm, n_samples=8)
+    assert mode == ALIGNED_DRAWS
+    assert aligned is cm
+
+
+def test_align_mismatch_fails_loud():
+    cm = _pf(np.ones((2, 2)), time=[1, 1], unit=[1, 2], level=SpatialLevel.CM)
+    with pytest.raises(ValueError, match="neither 1.*nor 8"):
+        align_country_to_grid(cm, n_samples=8)
+
+
+# --------------------------------------------------------------------------- reconcile_frames (fakes)
+
+
+class _ReorderingReconciler:
+    """Correct per-(time,country) scaler that returns rows in REVERSED order — exercises the
+    realign-by-index safety in reconcile_frames. Single-time inputs only (chunk slices)."""
+
+    def __init__(self, map_keys, map_vals):
+        self._country = {(int(t), int(g)): int(c) for (t, g), c in zip(map_keys, map_vals)}
+
+    def reconcile(self, cm_frame, pgm_frame):
+        pg = np.asarray(pgm_frame.values, dtype=np.float32)
+        out = np.empty_like(pg)
+        cm_lookup = {
+            (int(t), int(u)): cm_frame.values[i]
+            for i, (t, u) in enumerate(zip(cm_frame.index.time, cm_frame.index.unit))
+        }
+        # proportional per (time, country) per draw — every row lands in exactly one group
+        groups = {}
+        for i, (t, u) in enumerate(zip(pgm_frame.index.time, pgm_frame.index.unit)):
+            groups.setdefault((int(t), self._country[(int(t), int(u))]), []).append(i)
+        for (t, c), idxs in groups.items():
+            sub = pg[idxs]
+            total = cm_lookup[(t, c)]
+            scale = total / (sub.sum(axis=0, keepdims=True) + 1e-12)
+            out[idxs] = sub * scale
+        order = np.arange(pg.shape[0])[::-1]
+        rev = SpatioTemporalIndex(
+            np.asarray(pgm_frame.index.time)[order],
+            np.asarray(pgm_frame.index.unit)[order],
+            pgm_frame.index.level,
+        )
+        return PredictionFrame(out[order].astype(np.float32), rev)
+
+
+def test_reconcile_frames_realigns_reordered_port_output():
+    pgm, cm, mk, mv = _build_case(times=[1], n_samples=4, cm_point=True, seed=1)
+    out = reconcile_frames(_ReorderingReconciler(mk, mv), cm, pgm)
+    # despite the port reversing rows, output is realigned to the input grid index
+    np.testing.assert_array_equal(np.asarray(out.index.unit), np.asarray(pgm.index.unit))
+    np.testing.assert_array_equal(np.asarray(out.index.time), np.asarray(pgm.index.time))
+
+
+def test_reconcile_frames_empty_fails_loud():
+    empty = _pf(np.empty((0, 4), dtype=np.float32), time=[], unit=[], level=SpatialLevel.PGM)
+    cm = _pf([[1.0]], time=[1], unit=[1], level=SpatialLevel.CM)
+    with pytest.raises(ValueError, match="empty grid frame"):
+        reconcile_frames(_ReorderingReconciler(np.empty((0, 2), np.int64), np.empty((0,), np.int64)), cm, empty)
+
+
+def test_reconcile_frames_does_not_mutate_input():
+    pgm, cm, mk, mv = _build_case(times=[1], n_samples=4, cm_point=True, seed=2)
+    before = np.array(pgm.values, copy=True)
+    reconcile_frames(_ReorderingReconciler(mk, mv), cm, pgm)
+    np.testing.assert_array_equal(pgm.values, before)
+
+
+def test_reconcile_frames_carries_metadata():
+    pgm, cm, mk, mv = _build_case(times=[1], n_samples=4, cm_point=True, seed=3)
+    pgm = pgm.with_metadata(FrameMetadata(model="rusty_sibling", run_type="forecasting"))
+    out = reconcile_frames(_ReorderingReconciler(mk, mv), cm, pgm)
+    assert out.metadata is not None and out.metadata.model == "rusty_sibling"
+
+
+def test_reconcile_frames_logs_mode(caplog):
+    pgm, cm, mk, mv = _build_case(times=[1], n_samples=4, cm_point=True, seed=4)
+    with caplog.at_level(logging.INFO):
+        reconcile_frames(_ReorderingReconciler(mk, mv), cm, pgm)
+    assert any("mode=point-broadcast" in r.message for r in caplog.records)
+
+
+# --------------------------------------------------------------------------- real substrate (parity)
+
+vfr = pytest.importorskip("views_frames_reconcile")
+
+
+def _country_sums(frame, map_keys, map_vals):
+    """Per-(time, country) per-draw sums of grid cells, keyed by (time, country)."""
+    country = {(int(t), int(g)): int(c) for (t, g), c in zip(map_keys, map_vals)}
+    sums = {}
+    for i, (t, u) in enumerate(zip(frame.index.time, frame.index.unit)):
+        key = (int(t), country[(int(t), int(u))])
+        sums[key] = sums.get(key, 0.0) + frame.values[i]
+    return sums
+
+
+@pytest.mark.parametrize("cm_point", [True, False])
+def test_point_and_versions_sum_to_country_totals(cm_point):
+    pgm, cm, mk, mv = _build_case(times=[1, 2], n_samples=16, cm_point=cm_point, seed=5)
+    rec = vfr.ReconciliationModule(mk, mv)
+    out = reconcile_frames(rec, cm, pgm)
+
+    assert out.sample_count == 16  # draws preserved, not collapsed
+    assert (np.asarray(out.values) >= 0).all()  # non-negative
+
+    sums = _country_sums(out, mk, mv)
+    cm_lookup = {(int(t), int(u)): cm.values[i] for i, (t, u) in enumerate(zip(cm.index.time, cm.index.unit))}
+    for (t, c), grid_sum in sums.items():
+        expected = cm_lookup[(t, c)]
+        expected = np.repeat(expected, 16) if expected.shape[0] == 1 else expected
+        np.testing.assert_allclose(grid_sum, expected, rtol=1e-4, atol=1e-2)
+
+
+def test_chunk_by_time_equals_whole_frame():
+    pgm, cm, mk, mv = _build_case(times=[1, 2, 3], n_samples=8, cm_point=True, seed=6)
+    rec = vfr.ReconciliationModule(mk, mv)
+    chunked = reconcile_frames(rec, cm, pgm, chunk_by_time=True)
+    whole = reconcile_frames(rec, cm, pgm, chunk_by_time=False)
+    np.testing.assert_array_equal(chunked.values, whole.values)
+    np.testing.assert_array_equal(np.asarray(chunked.index.unit), np.asarray(whole.index.unit))
+
+
+def test_zeros_preserved():
+    pgm, cm, mk, mv = _build_case(times=[1], n_samples=8, cm_point=True, seed=7)
+    vals = np.array(pgm.values, copy=True)
+    vals[0, :] = 0.0  # force a zero grid cell
+    pgm = PredictionFrame(vals, pgm.index)
+    out = reconcile_frames(vfr.ReconciliationModule(mk, mv), cm, pgm)
+    np.testing.assert_array_equal(out.values[0], np.zeros(8, dtype=np.float32))

--- a/tests/test_modules/test_reconcile_frames.py
+++ b/tests/test_modules/test_reconcile_frames.py
@@ -149,9 +149,12 @@ def test_reconcile_frames_carries_metadata():
 
 def test_reconcile_frames_logs_mode(caplog):
     pgm, cm, _, _ = _build_case(times=[1], n_samples=4, cm_point=True, seed=4)
-    with caplog.at_level(logging.INFO):
+    # Target the module logger explicitly: a bare at_level(INFO) does not lower this
+    # logger's effective level, so an ambient WARNING config (as in CI) would filter the
+    # INFO record before caplog sees it.
+    with caplog.at_level(logging.INFO, logger="views_pipeline_core.modules.reconciliation.reconcile_frames"):
         reconcile_frames(_ReorderingReconciler(), cm, pgm)
-    assert any("mode=point-broadcast" in r.message for r in caplog.records)
+    assert any("mode=point-broadcast" in r.getMessage() for r in caplog.records)
 
 
 # --------------------------------------------------------------------------- real substrate (parity)

--- a/tests/test_modules/test_reconcile_frames.py
+++ b/tests/test_modules/test_reconcile_frames.py
@@ -95,40 +95,24 @@ def test_align_mismatch_fails_loud():
 
 
 class _ReorderingReconciler:
-    """Correct per-(time,country) scaler that returns rows in REVERSED order — exercises the
-    realign-by-index safety in reconcile_frames. Single-time inputs only (chunk slices)."""
-
-    def __init__(self, map_keys, map_vals):
-        self._country = {(int(t), int(g)): int(c) for (t, g), c in zip(map_keys, map_vals)}
+    """Pass-through port that returns rows in REVERSED order — exercises only the
+    realign-by-index safety in reconcile_frames. Value correctness (proportional scaling)
+    is covered by the real-substrate parity tests below, so this fake does no scaling."""
 
     def reconcile(self, cm_frame, pgm_frame):
         pg = np.asarray(pgm_frame.values, dtype=np.float32)
-        out = np.empty_like(pg)
-        cm_lookup = {
-            (int(t), int(u)): cm_frame.values[i]
-            for i, (t, u) in enumerate(zip(cm_frame.index.time, cm_frame.index.unit))
-        }
-        # proportional per (time, country) per draw — every row lands in exactly one group
-        groups = {}
-        for i, (t, u) in enumerate(zip(pgm_frame.index.time, pgm_frame.index.unit)):
-            groups.setdefault((int(t), self._country[(int(t), int(u))]), []).append(i)
-        for (t, c), idxs in groups.items():
-            sub = pg[idxs]
-            total = cm_lookup[(t, c)]
-            scale = total / (sub.sum(axis=0, keepdims=True) + 1e-12)
-            out[idxs] = sub * scale
         order = np.arange(pg.shape[0])[::-1]
         rev = SpatioTemporalIndex(
             np.asarray(pgm_frame.index.time)[order],
             np.asarray(pgm_frame.index.unit)[order],
             pgm_frame.index.level,
         )
-        return PredictionFrame(out[order].astype(np.float32), rev)
+        return PredictionFrame(pg[order].copy(), rev)
 
 
 def test_reconcile_frames_realigns_reordered_port_output():
-    pgm, cm, mk, mv = _build_case(times=[1], n_samples=4, cm_point=True, seed=1)
-    out = reconcile_frames(_ReorderingReconciler(mk, mv), cm, pgm)
+    pgm, cm, _, _ = _build_case(times=[1], n_samples=4, cm_point=True, seed=1)
+    out = reconcile_frames(_ReorderingReconciler(), cm, pgm)
     # despite the port reversing rows, output is realigned to the input grid index
     np.testing.assert_array_equal(np.asarray(out.index.unit), np.asarray(pgm.index.unit))
     np.testing.assert_array_equal(np.asarray(out.index.time), np.asarray(pgm.index.time))
@@ -138,33 +122,47 @@ def test_reconcile_frames_empty_fails_loud():
     empty = _pf(np.empty((0, 4), dtype=np.float32), time=[], unit=[], level=SpatialLevel.PGM)
     cm = _pf([[1.0]], time=[1], unit=[1], level=SpatialLevel.CM)
     with pytest.raises(ValueError, match="empty grid frame"):
-        reconcile_frames(_ReorderingReconciler(np.empty((0, 2), np.int64), np.empty((0,), np.int64)), cm, empty)
+        reconcile_frames(_ReorderingReconciler(), cm, empty)
+
+
+def test_reconcile_frames_duplicate_rows_fails_loud():
+    # two identical (time, unit) grid rows → must fail loud, not silently mis-realign
+    pgm = _pf(np.ones((2, 4), dtype=np.float32), time=[1, 1], unit=[11, 11], level=SpatialLevel.PGM)
+    cm = _pf([[10.0]], time=[1], unit=[1], level=SpatialLevel.CM)
+    with pytest.raises(ValueError, match="unique"):
+        reconcile_frames(_ReorderingReconciler(), cm, pgm)
 
 
 def test_reconcile_frames_does_not_mutate_input():
-    pgm, cm, mk, mv = _build_case(times=[1], n_samples=4, cm_point=True, seed=2)
+    pgm, cm, _, _ = _build_case(times=[1], n_samples=4, cm_point=True, seed=2)
     before = np.array(pgm.values, copy=True)
-    reconcile_frames(_ReorderingReconciler(mk, mv), cm, pgm)
+    reconcile_frames(_ReorderingReconciler(), cm, pgm)
     np.testing.assert_array_equal(pgm.values, before)
 
 
 def test_reconcile_frames_carries_metadata():
-    pgm, cm, mk, mv = _build_case(times=[1], n_samples=4, cm_point=True, seed=3)
+    pgm, cm, _, _ = _build_case(times=[1], n_samples=4, cm_point=True, seed=3)
     pgm = pgm.with_metadata(FrameMetadata(model="rusty_sibling", run_type="forecasting"))
-    out = reconcile_frames(_ReorderingReconciler(mk, mv), cm, pgm)
+    out = reconcile_frames(_ReorderingReconciler(), cm, pgm)
     assert out.metadata is not None and out.metadata.model == "rusty_sibling"
 
 
 def test_reconcile_frames_logs_mode(caplog):
-    pgm, cm, mk, mv = _build_case(times=[1], n_samples=4, cm_point=True, seed=4)
+    pgm, cm, _, _ = _build_case(times=[1], n_samples=4, cm_point=True, seed=4)
     with caplog.at_level(logging.INFO):
-        reconcile_frames(_ReorderingReconciler(mk, mv), cm, pgm)
+        reconcile_frames(_ReorderingReconciler(), cm, pgm)
     assert any("mode=point-broadcast" in r.message for r in caplog.records)
 
 
 # --------------------------------------------------------------------------- real substrate (parity)
+# Skip ONLY the substrate-dependent tests if views_frames_reconcile is absent (PyPI-only CI);
+# the orchestration tests above must always run.
+try:
+    import views_frames_reconcile as vfr
+except ImportError:  # pragma: no cover
+    vfr = None
 
-vfr = pytest.importorskip("views_frames_reconcile")
+_requires_vfr = pytest.mark.skipif(vfr is None, reason="views_frames_reconcile not installed")
 
 
 def _country_sums(frame, map_keys, map_vals):
@@ -177,6 +175,7 @@ def _country_sums(frame, map_keys, map_vals):
     return sums
 
 
+@_requires_vfr
 @pytest.mark.parametrize("cm_point", [True, False])
 def test_point_and_versions_sum_to_country_totals(cm_point):
     pgm, cm, mk, mv = _build_case(times=[1, 2], n_samples=16, cm_point=cm_point, seed=5)
@@ -194,6 +193,7 @@ def test_point_and_versions_sum_to_country_totals(cm_point):
         np.testing.assert_allclose(grid_sum, expected, rtol=1e-4, atol=1e-2)
 
 
+@_requires_vfr
 def test_chunk_by_time_equals_whole_frame():
     pgm, cm, mk, mv = _build_case(times=[1, 2, 3], n_samples=8, cm_point=True, seed=6)
     rec = vfr.ReconciliationModule(mk, mv)
@@ -203,6 +203,7 @@ def test_chunk_by_time_equals_whole_frame():
     np.testing.assert_array_equal(np.asarray(chunked.index.unit), np.asarray(whole.index.unit))
 
 
+@_requires_vfr
 def test_zeros_preserved():
     pgm, cm, mk, mv = _build_case(times=[1], n_samples=8, cm_point=True, seed=7)
     vals = np.array(pgm.values, copy=True)

--- a/views_pipeline_core/modules/reconciliation/reconcile_frames.py
+++ b/views_pipeline_core/modules/reconciliation/reconcile_frames.py
@@ -92,6 +92,13 @@ def reconcile_frames(
     """
     if pgm_frame.n_rows == 0:
         raise ValueError("Cannot reconcile an empty grid frame (pgm_frame has 0 rows).")
+    if not pgm_frame.index.has_unique_rows():
+        # The per-time chunk reassembly realigns by (time, unit) via reindex/searchsorted,
+        # which silently misbehave on duplicate keys (register C-21). Fail loud instead.
+        raise ValueError(
+            "reconcile_frames requires unique (time, unit) grid rows; the pgm frame has "
+            "duplicates, which would corrupt row realignment."
+        )
 
     aligned, mode = align_country_to_grid(cm_frame, pgm_frame.sample_count)
     logger.info(

--- a/views_pipeline_core/modules/reconciliation/reconcile_frames.py
+++ b/views_pipeline_core/modules/reconciliation/reconcile_frames.py
@@ -1,0 +1,121 @@
+"""Frames-native reconciliation orchestration for the PredictionFrame path (#234, epic #233).
+
+`PredictionFrameEnsembleManager` already holds `views_frames.PredictionFrame`s, so —
+unlike the DataFrame path's `adapter.reconcile_datasets` (which stacks pandas list-in-cell
+columns into arrays and writes them back) — the frames path needs **no dataset↔frame
+bridge**. This module is the thin, frames-in/frames-out orchestration the manager calls:
+it aligns the country (cm) forecast to the grid's draw count, reconciles per time step
+(bounded memory), and returns a **new** reconciled grid frame.
+
+It imports **only** `views_frames` + the `Reconciler` port — never the dataset god-class,
+pandas, or `adapter.reconcile_datasets` (ADP/CRP: the frames path must not inherit the
+pandas-era write-side orchestration).
+
+Two reconciliation **modes**, distinguished by the country frame's sample count:
+  * ``point-broadcast`` — a point cm forecast (``sample_count == 1``) is broadcast across
+    the grid's ``S`` draws; every draw is rescaled to the same country total.
+  * ``aligned-draws``   — a cm forecast that already carries ``S`` draws is scaled
+    draw-for-draw. This is a **per-draw approximation** (register C-200b): the pairing of
+    grid-draw ``s`` to country-draw ``s`` is only meaningful when the two share a draw
+    identity; the principled joint upgrade is tracked in views-frames#145.
+
+The point-broadcast tiling lives here WET for now; the DRY home is a native broadcast in
+``views_frames_reconcile`` (views-frames#143).
+"""
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Tuple
+
+import numpy as np
+from views_frames import PredictionFrame, SpatioTemporalIndex
+
+if TYPE_CHECKING:  # the port is a lightweight Protocol; keep imports frames-only at runtime
+    from views_pipeline_core.domain.reconciliation import Reconciler
+
+logger = logging.getLogger(__name__)
+
+POINT_BROADCAST = "point-broadcast"
+ALIGNED_DRAWS = "aligned-draws"
+
+
+def align_country_to_grid(
+    cm_frame: PredictionFrame, n_samples: int
+) -> Tuple[PredictionFrame, str]:
+    """Make the country frame's sample axis match the grid's ``n_samples``.
+
+    Returns ``(aligned_cm_frame, mode)``. The reconciler requires equal sample counts
+    (``views_frames_reconcile`` validation), so a point country must be broadcast before
+    it can scale a draws grid.
+
+    * ``cm.sample_count == n_samples`` → pass through (``aligned-draws``).
+    * ``cm.sample_count == 1``        → tile the point across the draw axis (``point-broadcast``).
+    * otherwise                       → fail loud (no silent coercion).
+    """
+    n_cm = cm_frame.sample_count
+    if n_cm == n_samples:
+        return cm_frame, ALIGNED_DRAWS
+    if n_cm == 1:
+        tiled = np.tile(np.asarray(cm_frame.values, dtype=np.float32), (1, n_samples))
+        return PredictionFrame(tiled, cm_frame.index), POINT_BROADCAST
+    raise ValueError(
+        f"Cannot reconcile: country frame has sample_count={n_cm}, which is neither 1 "
+        f"(point, broadcast) nor {n_samples} (the grid's draw count). A draws country "
+        f"forecast must carry exactly the grid's number of draws."
+    )
+
+
+def _concat_frames(frames: list[PredictionFrame]) -> PredictionFrame:
+    """Row-concatenate same-level frames (used to reassemble per-time chunks)."""
+    values = np.vstack([np.asarray(f.values, dtype=np.float32) for f in frames])
+    time = np.concatenate([np.asarray(f.index.time, dtype=np.int64) for f in frames])
+    unit = np.concatenate([np.asarray(f.index.unit, dtype=np.int64) for f in frames])
+    return PredictionFrame(values, SpatioTemporalIndex(time, unit, frames[0].index.level))
+
+
+def reconcile_frames(
+    reconciler: "Reconciler",
+    cm_frame: PredictionFrame,
+    pgm_frame: PredictionFrame,
+    *,
+    chunk_by_time: bool = True,
+) -> PredictionFrame:
+    """Reconcile a grid (pgm) frame to country (cm) totals via the injected port.
+
+    The country forecast is aligned to the grid's draw count (point-broadcast or
+    aligned-draws), then reconciled. With ``chunk_by_time`` (default), reconciliation runs
+    one time step at a time so a global-volume × S-draw frame never has to be held whole
+    (register C-200a); the chunks are reassembled in the input grid's row order. The
+    result is a **new** frame — the input ``pgm_frame`` is never mutated.
+
+    Returns the reconciled grid frame, carrying ``pgm_frame``'s metadata if any.
+    """
+    if pgm_frame.n_rows == 0:
+        raise ValueError("Cannot reconcile an empty grid frame (pgm_frame has 0 rows).")
+
+    aligned, mode = align_country_to_grid(cm_frame, pgm_frame.sample_count)
+    logger.info(
+        "reconcile_frames: mode=%s (%d grid rows, %d draws)%s",
+        mode,
+        pgm_frame.n_rows,
+        pgm_frame.sample_count,
+        " — per-draw approximation (C-200b)" if mode == ALIGNED_DRAWS else "",
+    )
+
+    if chunk_by_time:
+        pg_time = np.asarray(pgm_frame.index.time, dtype=np.int64)
+        cm_time = np.asarray(aligned.index.time, dtype=np.int64)
+        chunks: list[PredictionFrame] = []
+        for t in np.unique(pg_time):
+            pg_t = pgm_frame.select(pg_time == t)
+            cm_t = aligned.select(cm_time == t)
+            chunks.append(reconciler.reconcile(cm_t, pg_t))
+        reconciled = _concat_frames(chunks)
+    else:
+        reconciled = reconciler.reconcile(aligned, pgm_frame)
+
+    # Never trust the port's row order: realign to the input grid's index.
+    reconciled = reconciled.reindex(pgm_frame.index)
+    if pgm_frame.metadata is not None:
+        reconciled = reconciled.with_metadata(pgm_frame.metadata)
+    return reconciled


### PR DESCRIPTION
**Epic:** #233 · **Story S1** (#234) · first story, self-contained.

Adds `views_pipeline_core/modules/reconciliation/reconcile_frames.py` — the frames-native reconciliation orchestration the `PredictionFrameEnsembleManager` will call (wiring is S3/#236). **No** dataset/pandas/`adapter.reconcile_datasets` coupling: PFE already holds frames, so this path needs no dataset↔frame bridge (C-200c avoided).

## What
- `align_country_to_grid(cm_frame, n_samples)` → `(frame, mode)`: point-broadcast (cm `sample_count==1`, tile across S draws) / aligned-draws (cm carries S) / **fail loud** otherwise.
- `reconcile_frames(reconciler, cm_frame, pgm_frame, *, chunk_by_time=True)`: aligns, reconciles **per time step** (bounded memory, C-200a), realigns the port output by `(time,unit)`, returns a **new** frame (no mutation), carries `pgm` metadata through, logs the **mode** (aligned-draws flagged as the per-draw approximation, C-200b).
- Mode is **logged/returned only** — persisting it in `FrameMetadata` is views-frames#144 (no such field exists yet).

## Tests (`tests/test_modules/test_reconcile_frames.py`)
align modes + fail-loud; reorder-safety (realign by index); empty fail-loud; no-mutation; metadata pass-through; mode log; **real-substrate parity** (`views_frames_reconcile`, capability-skipped if absent): point & versions sum to country totals per draw, draws preserved, zeros preserved, non-negative, **chunk-by-time == whole-frame bit-exact**.

## Notes
- The `views-frames ^1.7` floor (which ships `views_frames_reconcile`) is declared by PR #232; the real-substrate tests `importorskip` it so CI is green regardless.
- Local: `conda run -n views_pipeline ruff check` + `pytest tests/test_modules/test_reconcile_frames.py` → 12 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)