### PR TITLE
S2 (#235) — country (cm) forecast → PredictionFrame loader

### DIFF
--- a/tests/test_managers/test_cm_forecast_loader.py
+++ b/tests/test_managers/test_cm_forecast_loader.py
@@ -1,0 +1,74 @@
+"""#235 (epic #233) — the country (cm) forecast → PredictionFrame loader.
+
+Exercises `load_cm_frame` with the two ingest seams stubbed (the path locator and
+`read_dataframe`), so no real model dir or parquet I/O is needed: point vs draws cm
+forecasts, plus the two fail-loud paths (no forecast, missing target column).
+"""
+import types
+
+import numpy as np
+import pandas as pd
+import pytest
+from views_frames import SpatialLevel
+
+import views_pipeline_core.managers.ensemble.cm_forecast_loader as cfl
+
+
+def _fake_epm(paths):
+    """Replace EnsemblePathManager(name) with a stub exposing the path locator."""
+    return lambda name: types.SimpleNamespace(
+        _get_generated_predictions_data_file_paths=lambda run_type: list(paths)
+    )
+
+
+def _cm_df(point=True):
+    idx = pd.MultiIndex.from_tuples(
+        [(1, 100), (1, 200), (2, 100), (2, 200)], names=["month_id", "country_id"]
+    )
+    if point:
+        values = [10.0, 20.0, 30.0, 40.0]
+    else:  # draws: each cell a 3-sample array
+        values = [np.arange(3, dtype=np.float32) + b for b in (10, 20, 30, 40)]
+    return pd.DataFrame({"pred_sb": values}, index=idx)
+
+
+def test_load_cm_frame_point(monkeypatch):
+    monkeypatch.setattr(cfl, "EnsemblePathManager", _fake_epm(["latest.parquet"]))
+    monkeypatch.setattr(cfl, "read_dataframe", lambda p: _cm_df(point=True))
+
+    frame = cfl.load_cm_frame("cruel_summer", "sb", "forecasting")
+    assert frame.index.level == SpatialLevel.CM
+    assert frame.sample_count == 1
+    assert frame.n_rows == 4
+    np.testing.assert_array_equal(np.asarray(frame.index.time), [1, 1, 2, 2])
+    np.testing.assert_array_equal(np.asarray(frame.index.unit), [100, 200, 100, 200])
+    np.testing.assert_array_equal(frame.values.ravel(), [10, 20, 30, 40])
+
+
+def test_load_cm_frame_draws(monkeypatch):
+    monkeypatch.setattr(cfl, "EnsemblePathManager", _fake_epm(["latest.parquet"]))
+    monkeypatch.setattr(cfl, "read_dataframe", lambda p: _cm_df(point=False))
+
+    frame = cfl.load_cm_frame("cruel_summer", "sb", "forecasting")
+    assert frame.sample_count == 3  # draws carried through
+    assert frame.n_rows == 4
+
+
+def test_load_cm_frame_accepts_prefixed_target(monkeypatch):
+    monkeypatch.setattr(cfl, "EnsemblePathManager", _fake_epm(["latest.parquet"]))
+    monkeypatch.setattr(cfl, "read_dataframe", lambda p: _cm_df(point=True))
+    frame = cfl.load_cm_frame("cruel_summer", "pred_sb", "forecasting")  # already prefixed
+    assert frame.n_rows == 4
+
+
+def test_load_cm_frame_no_forecast_fails_loud(monkeypatch):
+    monkeypatch.setattr(cfl, "EnsemblePathManager", _fake_epm([]))  # nothing on disk
+    with pytest.raises(ValueError, match="no local forecast found"):
+        cfl.load_cm_frame("cruel_summer", "sb", "forecasting")
+
+
+def test_load_cm_frame_missing_column_fails_loud(monkeypatch):
+    monkeypatch.setattr(cfl, "EnsemblePathManager", _fake_epm(["latest.parquet"]))
+    monkeypatch.setattr(cfl, "read_dataframe", lambda p: _cm_df(point=True))
+    with pytest.raises(ValueError, match="no 'pred_ns' column"):
+        cfl.load_cm_frame("cruel_summer", "ns", "forecasting")

--- a/tests/test_managers/test_cm_forecast_loader.py
+++ b/tests/test_managers/test_cm_forecast_loader.py
@@ -67,6 +67,17 @@ def test_load_cm_frame_no_forecast_fails_loud(monkeypatch):
         cfl.load_cm_frame("cruel_summer", "sb", "forecasting")
 
 
+def test_load_cm_frame_locate_error_fails_loud_friendly(monkeypatch):
+    # model dir / data_generated absent → EnsemblePathManager raises FileNotFoundError
+    # (an OSError); it must be wrapped in the friendly fail-loud ValueError, not leak raw.
+    def _raises(name):
+        raise FileNotFoundError("Ensemble directory ... does not exist")
+
+    monkeypatch.setattr(cfl, "EnsemblePathManager", _raises)
+    with pytest.raises(ValueError, match="could not locate a forecast"):
+        cfl.load_cm_frame("cruel_summer", "sb", "forecasting")
+
+
 def test_load_cm_frame_missing_column_fails_loud(monkeypatch):
     monkeypatch.setattr(cfl, "EnsemblePathManager", _fake_epm(["latest.parquet"]))
     monkeypatch.setattr(cfl, "read_dataframe", lambda p: _cm_df(point=True))

--- a/views_pipeline_core/managers/ensemble/cm_forecast_loader.py
+++ b/views_pipeline_core/managers/ensemble/cm_forecast_loader.py
@@ -1,0 +1,76 @@
+"""Load a country (cm) model's forecast as a views_frames PredictionFrame (#235, epic #233).
+
+`PredictionFrameEnsembleManager` reconciles a grid ensemble to a country model named by the
+`reconcile_with` config (wiring is S3/#236). That country forecast is read here at the
+**ingest edge** (pandas) and handed to the frames-native reconciler as a cm `PredictionFrame`.
+
+A free function, not a manager method: it keeps the reconciliation ingest testable without
+constructing the (large) PFE, and keeps that class from growing (epic #233 design — external
+functions the manager calls).
+
+PFE is a **local-disk** manager (it loads constituent forecasts from `data_generated`), so the
+country forecast is located the same way. The DataFrame `EnsembleManager`'s prediction-store
+path is intentionally out of scope here: it needs a generated pred-store name + run creation
+(`_get_pred_store_name`), which PFE has no counterpart for. Today's cm models are **point**
+DataFrame forecasts, so the parquet's `pred_{target}` column is stacked into a `(N, S)` array
+(S=1 for a point model, S>1 for a draws-emitting one) and wrapped as a cm frame;
+`reconcile_frames.align_country_to_grid` then matches it to the grid's draw count.
+
+Missing rows are **not** filled (unlike `_CDataset` preprocessing): a country absent from the
+forecast must surface as the reconciler's fail-loud "missing country", not a silent zero total.
+"""
+from __future__ import annotations
+
+import numpy as np
+from views_frames import PredictionFrame, SpatialLevel, SpatioTemporalIndex
+
+from views_pipeline_core.files.utils import read_dataframe
+from views_pipeline_core.managers.ensemble.ensemble import EnsemblePathManager
+
+
+def _prediction_column(target: str) -> str:
+    """The `pred_*` column for a target (idempotent if already prefixed)."""
+    return target if target.startswith("pred_") else f"pred_{target}"
+
+
+def load_cm_frame(cm_model: str, target: str, run_type: str) -> PredictionFrame:
+    """Locate `cm_model`'s latest local forecast and return its `pred_{target}` as a cm frame.
+
+    Args:
+        cm_model: the country model named by `reconcile_with`.
+        target: the prediction target (with or without the `pred_` prefix).
+        run_type: e.g. ``"forecasting"`` — selects the generated-predictions file set.
+
+    Raises:
+        ValueError: no local forecast for `cm_model`, or it lacks the target column. Both are
+            fail-loud — reconciliation cannot proceed without the country totals.
+    """
+    paths = EnsemblePathManager(cm_model)._get_generated_predictions_data_file_paths(
+        run_type=run_type
+    )
+    if not paths:
+        raise ValueError(
+            f"Cannot reconcile: no local forecast found for country model '{cm_model}' "
+            f"(run_type={run_type}). Run the country model before reconciling."
+        )
+    df = read_dataframe(paths[0])
+
+    column = _prediction_column(target)
+    if column not in df.columns:
+        available = sorted(c for c in df.columns if c.startswith("pred_"))
+        raise ValueError(
+            f"Country model '{cm_model}' forecast has no '{column}' column; "
+            f"available prediction columns: {available}."
+        )
+
+    # Stack the per-row prediction cells (scalars for point, sample arrays for draws) into a
+    # dense (N, S) float32 array — mirrors the cell contract in reconciliation/adapter.py.
+    cells = df[column].to_numpy()
+    rows = [np.atleast_1d(np.asarray(v, dtype=np.float32)).ravel() for v in cells]
+    y_pred = np.vstack(rows) if rows else np.empty((0, 1), dtype=np.float32)
+    index = SpatioTemporalIndex(
+        time=df.index.get_level_values(0).to_numpy(dtype=np.int64),
+        unit=df.index.get_level_values(1).to_numpy(dtype=np.int64),
+        level=SpatialLevel.CM,
+    )
+    return PredictionFrame(y_pred, index)

--- a/views_pipeline_core/managers/ensemble/cm_forecast_loader.py
+++ b/views_pipeline_core/managers/ensemble/cm_forecast_loader.py
@@ -27,10 +27,15 @@ from views_frames import PredictionFrame, SpatialLevel, SpatioTemporalIndex
 from views_pipeline_core.files.utils import read_dataframe
 from views_pipeline_core.managers.ensemble.ensemble import EnsemblePathManager
 
+#: Prefix marking a DataFrame's prediction columns (e.g. ``pred_sb``).
+PREDICTION_COLUMN_PREFIX = "pred_"
+
 
 def _prediction_column(target: str) -> str:
     """The `pred_*` column for a target (idempotent if already prefixed)."""
-    return target if target.startswith("pred_") else f"pred_{target}"
+    if target.startswith(PREDICTION_COLUMN_PREFIX):
+        return target
+    return f"{PREDICTION_COLUMN_PREFIX}{target}"
 
 
 def load_cm_frame(cm_model: str, target: str, run_type: str) -> PredictionFrame:
@@ -45,9 +50,19 @@ def load_cm_frame(cm_model: str, target: str, run_type: str) -> PredictionFrame:
         ValueError: no local forecast for `cm_model`, or it lacks the target column. Both are
             fail-loud — reconciliation cannot proceed without the country totals.
     """
-    paths = EnsemblePathManager(cm_model)._get_generated_predictions_data_file_paths(
-        run_type=run_type
-    )
+    # Locating the forecast can raise before we reach the `not paths` guard: constructing
+    # EnsemblePathManager validates the model dir (FileNotFoundError if absent), and the
+    # path scan does an unguarded `data_generated.iterdir()` (FileNotFoundError if the model
+    # has never produced a forecast). Wrap both so the failure is loud AND actionable.
+    try:
+        paths = EnsemblePathManager(cm_model)._get_generated_predictions_data_file_paths(
+            run_type=run_type
+        )
+    except OSError as e:
+        raise ValueError(
+            f"Cannot reconcile: could not locate a forecast for country model '{cm_model}' "
+            f"(run_type={run_type}): {e}. Run the country model before reconciling."
+        ) from e
     if not paths:
         raise ValueError(
             f"Cannot reconcile: no local forecast found for country model '{cm_model}' "
@@ -57,7 +72,7 @@ def load_cm_frame(cm_model: str, target: str, run_type: str) -> PredictionFrame:
 
     column = _prediction_column(target)
     if column not in df.columns:
-        available = sorted(c for c in df.columns if c.startswith("pred_"))
+        available = sorted(c for c in df.columns if c.startswith(PREDICTION_COLUMN_PREFIX))
         raise ValueError(
             f"Country model '{cm_model}' forecast has no '{column}' column; "
             f"available prediction columns: {available}."


### PR DESCRIPTION
**Epic:** #233 · **Story S2** (#235). Independent of S1; consumed by S3 (#236).

Adds `views_pipeline_core/managers/ensemble/cm_forecast_loader.py::load_cm_frame(cm_model, target, run_type) -> PredictionFrame` — the country-forecast ingest the PFE reconciliation path needs.

## Design
- **Free function, not a PFE method** — keeps the ingest testable without constructing the 786-line manager, and keeps the god-class from growing (epic design: external functions the manager calls).
- **Local-disk only**, matching PFE's own data model (it loads constituent forecasts from `data_generated`). The DataFrame `EnsembleManager`'s prediction-store path is out of scope: it needs `_get_pred_store_name` + run creation, which PFE has no counterpart for.
- **Direct parquet read + cell-stacking**, not `_CDataset` — so a country **missing** from the forecast surfaces as the reconciler's fail-loud "missing country", not a silently 0-filled total. Cell-stacking mirrors `adapter._stack_cells`'s contract (WET; rule-of-three extraction later).
- **Fail loud** on no forecast / missing target column.

## Tests (`tests/test_managers/test_cm_forecast_loader.py`)
Path locator + `read_dataframe` stubbed (no real model dir / parquet I/O): point (S=1), draws (S>1), already-`pred_`-prefixed target, and both fail-loud paths.

Local: `ruff` clean, `pytest` 5 passed; no import cycle with PFE.

🤖 Generated with [Claude Code](https://claude.com/claude-code)