### PR TITLE
S3 (#236) — wire reconciliation into PredictionFrameEnsembleManager + sniffer

### DIFF
--- a/tests/test_managers/test_prediction_frame_ensemble_manager.py
+++ b/tests/test_managers/test_prediction_frame_ensemble_manager.py
@@ -19,6 +19,7 @@ from views_pipeline_core.cli.args import ForecastingModelArgs
 from views_pipeline_core.exceptions import PipelineException
 from views_pipeline_core.managers.ensemble import EnsemblePathManager
 from views_pipeline_core.managers.ensemble.dataframe_ensemble import EnsembleContext
+import views_pipeline_core.managers.ensemble.prediction_frame_ensemble as _pfe_mod
 from views_pipeline_core.managers.ensemble.prediction_frame_ensemble import (
     SUPPORTED_PF_AGGREGATION_METHODS,
     _aggregate_prediction_frames,
@@ -872,8 +873,6 @@ class TestConfigModelsetMerge:
 # ============================================================================
 # Reconciliation wiring (#236, epic #233)
 # ============================================================================
-
-import views_pipeline_core.managers.ensemble.prediction_frame_ensemble as _pfe_mod  # noqa: E402
 
 
 def _recon_context(mock_ensemble_path):

--- a/tests/test_managers/test_prediction_frame_ensemble_manager.py
+++ b/tests/test_managers/test_prediction_frame_ensemble_manager.py
@@ -383,22 +383,9 @@ class TestPredictionFrameEnsembleConstants:
             ctx.prediction_format = "dataframe"
 
 
-class TestPredictionFrameReconciliationFailsLoud:
-    """#195 review: PFE has no reconciliation path yet (#200). A configured
-    reconciliation must fail loud, not be silently dropped to None."""
-
-    def test_build_context_raises_when_reconciliation_configured(self, pf_manager, sample_args):
-        cfg = COMBINED_CONFIGS.copy()
-        cfg["reconciliation"] = "pgm_cm_point"
-        cfg["reconcile_with"] = "some_cm_model"
-        pf_manager._config_manager.get_combined_config.return_value = cfg
-        with pytest.raises(PipelineException, match="#200"):
-            pf_manager._build_context(sample_args)
-
-    def test_build_context_ok_when_reconciliation_none(self, pf_manager, sample_args):
-        # reconciliation=None (the norm for PFE) builds a context with reconciliation off.
-        ctx = pf_manager._build_context(sample_args)
-        assert ctx.reconciliation is None
+# NOTE: PFE's former "refuse reconciliation" guard (#200) was removed in #236 when the
+# frames-native reconciliation path landed; its characterization tests are superseded by
+# TestPredictionFrameReconciliationWiring (below).
 
 
 # ============================================================================
@@ -880,3 +867,87 @@ class TestConfigModelsetMerge:
             "models": ["old"],
             "description": "Test",
         }
+
+
+# ============================================================================
+# Reconciliation wiring (#236, epic #233)
+# ============================================================================
+
+import views_pipeline_core.managers.ensemble.prediction_frame_ensemble as _pfe_mod  # noqa: E402
+
+
+def _recon_context(mock_ensemble_path):
+    """An EnsembleContext that requests frames-native reconciliation."""
+    return EnsembleContext(
+        configs=COMBINED_CONFIGS.copy(),
+        model_path=mock_ensemble_path,
+        run_type="forecasting",
+        project="p",
+        eval_type="standard",
+        args=ForecastingModelArgs(
+            run_type="forecasting", train=False, evaluate=False,
+            forecast=True, saved=True, eval_type="standard",
+        ),
+        models=["hydra_alpha"],
+        aggregation="concat",
+        targets=["ged_sb"],
+        reconciliation="pgm_cm",
+        reconcile_with="cm_model",
+        use_weights=False,
+        weights={},
+        timestamp="20241105_120000",
+        deployment_status="deployed",
+        prediction_format="prediction_frame",
+        partition_dict=PARTITION_DICT,
+    )
+
+
+class TestPredictionFrameReconciliationWiring:
+    def test_build_context_reads_reconciliation(self, pf_manager, sample_args):
+        cfg = COMBINED_CONFIGS.copy()
+        cfg["reconciliation"] = "pgm_cm"
+        cfg["reconcile_with"] = "cm_model"
+        pf_manager._config_manager.get_combined_config.return_value = cfg
+        ctx = pf_manager._build_context(sample_args)
+        assert ctx.reconciliation == "pgm_cm"
+        assert ctx.reconcile_with == "cm_model"
+
+    def test_build_context_no_reconciliation_does_not_raise(self, pf_manager, sample_args):
+        # default config has reconciliation=None — the old refusal guard is gone.
+        ctx = pf_manager._build_context(sample_args)
+        assert ctx.reconciliation is None
+        assert ctx.reconcile_with is None
+
+    def test_reconcile_forecast_fails_loud_without_reconciler(self, pf_manager, mock_ensemble_path):
+        pf_manager._reconciler = None
+        ctx = _recon_context(mock_ensemble_path)
+        with pytest.raises(PipelineException, match="no Reconciler was injected"):
+            pf_manager._reconcile_forecast(_make_pf(n_rows=2, n_samples=4), "ged_sb", ctx)
+
+    def test_reconcile_forecast_wires_loader_and_port(self, pf_manager, mock_ensemble_path, monkeypatch):
+        # Verify _reconcile_forecast integrates: inject reconciler, load the cm frame for the
+        # right (model, target, run_type), and pass (reconciler, cm, agg) to reconcile_frames.
+        fake_reconciler = object()
+        pf_manager._reconciler = fake_reconciler
+        agg = _make_pf(n_rows=2, n_samples=4)
+        cm_sentinel = _make_pf(n_rows=2, n_samples=4)
+        out_sentinel = _make_pf(n_rows=2, n_samples=4)
+        seen = {}
+
+        def _fake_load(cm_model, target, run_type):
+            seen["load"] = (cm_model, target, run_type)
+            return cm_sentinel
+
+        def _fake_reconcile(reconciler, cm_frame, pgm_frame):
+            seen["reconcile"] = (reconciler is fake_reconciler, cm_frame is cm_sentinel, pgm_frame is agg)
+            return out_sentinel
+
+        monkeypatch.setattr(_pfe_mod, "load_cm_frame", _fake_load)
+        monkeypatch.setattr(_pfe_mod, "reconcile_frames", _fake_reconcile)
+
+        ctx = _recon_context(mock_ensemble_path)
+        result = pf_manager._reconcile_forecast(agg, "ged_sb", ctx)
+
+        assert result is out_sentinel
+        assert seen["load"] == ("cm_model", "ged_sb", "forecasting")
+        assert seen["reconcile"] == (True, True, True)

--- a/tests/test_modules/test_core_config_sniffer.py
+++ b/tests/test_modules/test_core_config_sniffer.py
@@ -444,6 +444,24 @@ class TestReconciliationConfigValidation:
         with pytest.raises(ValueError, match="reconcile_with"):
             CoreConfigSniffer(configs, _valid_partition(), target="model").sniff_all("calibration")
 
+    def test_pgm_cm_frames_type_with_reconcile_with_passes(self):
+        # "pgm_cm" = the frames-native PFE reconciliation path (#236, epic #233).
+        configs = {
+            **_valid_configs(),
+            "reconciliation": "pgm_cm",
+            "reconcile_with": "cruel_summer",
+        }
+        CoreConfigSniffer(configs, _valid_partition(), target="model").sniff_all("calibration")
+
+    def test_pgm_cm_frames_type_without_reconcile_with_raises(self):
+        configs = {
+            **_valid_configs(),
+            "reconciliation": "pgm_cm",
+            "reconcile_with": None,
+        }
+        with pytest.raises(ValueError, match="reconcile_with"):
+            CoreConfigSniffer(configs, _valid_partition(), target="model").sniff_all("calibration")
+
 
 # ---------------------------------------------------------------------------
 # Ensemble-aware validation — universal vs model-only mandatory keys

--- a/views_pipeline_core/domain/reconciliation_port.py
+++ b/views_pipeline_core/domain/reconciliation_port.py
@@ -36,7 +36,7 @@ class Reconciler(Protocol):
 #: was injected at the composition root. Single source of truth for both ensemble
 #: managers (no silent-off — see #194/#195).
 RECONCILER_NOT_INJECTED_MSG = (
-    "Reconciliation 'pgm_cm_point' is configured but no Reconciler was injected. "
+    "Reconciliation is configured but no Reconciler was injected. "
     "The composition root (the views-models ensemble main) must inject a concrete "
     "Reconciler. See issue #195."
 )

--- a/views_pipeline_core/managers/ensemble/prediction_frame_ensemble.py
+++ b/views_pipeline_core/managers/ensemble/prediction_frame_ensemble.py
@@ -23,13 +23,18 @@ import wandb
 
 from views_pipeline_core.cli.args import ForecastingModelArgs
 from views_pipeline_core.data.prediction_frame import PredictionFrame
-from views_pipeline_core.domain.reconciliation_port import Reconciler
+from views_pipeline_core.domain.reconciliation_port import (
+    RECONCILER_NOT_INJECTED_MSG,
+    Reconciler,
+)
 from views_pipeline_core.exceptions import PipelineException
 from views_pipeline_core.managers.prediction.prediction_frame_io import load_pf, save_pf
 from views_pipeline_core.files.utils import handle_ensemble_log_creation
+from views_pipeline_core.modules.reconciliation.reconcile_frames import reconcile_frames
 from views_pipeline_core.modules.validation.core_config_sniffer import CoreConfigSniffer
 from views_pipeline_core.modules.validation.ensemble import validate_ensemble_model
 
+from .cm_forecast_loader import load_cm_frame
 from .dataframe_ensemble import EnsembleContext
 from .ensemble import EnsemblePathManager
 
@@ -275,17 +280,10 @@ class PredictionFrameEnsembleManager:
 
     def _build_context(self, args: ForecastingModelArgs) -> EnsembleContext:
         c = self.configs
-        # Fail loud (no silent-off): PFE has no reconciliation path yet (#200).
-        # If a config requests reconciliation, refuse it rather than silently
-        # dropping it to None below. The injected `reconciler` is accepted for
-        # uniform composition-root construction but is not wired here yet.
-        if c.get("reconciliation") is not None:
-            raise PipelineException(
-                "Reconciliation is configured but prediction_frame ensembles do not "
-                "support reconciliation yet (probabilistic PFE reconciliation is #200). "
-                "Remove 'reconciliation' from the config, or run a DataFrame ensemble.",
-                wandb_module=self._wandb_module,
-            )
+        # Reconciliation is read from config and applied in `_forecast_ensemble` via the
+        # injected `Reconciler` port (#236, epic #233). A configured reconciliation with no
+        # injected reconciler fails loud at apply time (RECONCILER_NOT_INJECTED_MSG) — no
+        # silent-off.
         return EnsembleContext(
             configs=c,
             model_path=self._ensemble_path,
@@ -296,8 +294,8 @@ class PredictionFrameEnsembleManager:
             models=c["models"],
             aggregation=c["aggregation"],
             targets=c.get("targets", c.get("regression_targets", [])),
-            reconciliation=None,
-            reconcile_with=None,
+            reconciliation=c.get("reconciliation"),
+            reconcile_with=c.get("reconcile_with"),
             use_weights=c.get("use_weights", False),
             weights=c.get("weights", {}),
             timestamp=c.get("timestamp", ""),
@@ -572,6 +570,8 @@ class PredictionFrameEnsembleManager:
             agg_pf = _aggregate_prediction_frames(
                 frames, method=ctx.aggregation
             )
+            if ctx.reconciliation:
+                agg_pf = self._reconcile_forecast(agg_pf, target, ctx)
             save_dir = (
                 self._ensemble_path.data_generated
                 / f"predictions_{ctx.run_type}_{ctx.timestamp}"
@@ -581,6 +581,22 @@ class PredictionFrameEnsembleManager:
             forecasts[target] = agg_pf
 
         return forecasts
+
+    def _reconcile_forecast(
+        self, agg_pf: PredictionFrame, target: str, ctx: EnsembleContext
+    ) -> PredictionFrame:
+        """Reconcile one aggregated grid forecast to its country (cm) totals.
+
+        Fail loud (no silent-off) if reconciliation is configured but no concrete
+        `Reconciler` was injected at the composition root. Geography is held by the
+        injected reconciler (views-models) — pipeline-core builds no map here.
+        """
+        if self._reconciler is None:
+            raise PipelineException(
+                RECONCILER_NOT_INJECTED_MSG, wandb_module=self._wandb_module
+            )
+        cm_frame = load_cm_frame(ctx.reconcile_with, target, ctx.run_type)
+        return reconcile_frames(self._reconciler, cm_frame, agg_pf)
 
     # ------------------------------------------------------------------
     # Model artifact execution (subprocess delegation)

--- a/views_pipeline_core/managers/ensemble/prediction_frame_ensemble.py
+++ b/views_pipeline_core/managers/ensemble/prediction_frame_ensemble.py
@@ -596,7 +596,14 @@ class PredictionFrameEnsembleManager:
                 RECONCILER_NOT_INJECTED_MSG, wandb_module=self._wandb_module
             )
         cm_frame = load_cm_frame(ctx.reconcile_with, target, ctx.run_type)
-        return reconcile_frames(self._reconciler, cm_frame, agg_pf)
+        reconciled = reconcile_frames(self._reconciler, cm_frame, agg_pf)
+        logger.info(
+            "Reconciled '%s' to country totals from '%s' (%s).",
+            target,
+            ctx.reconcile_with,
+            ctx.reconciliation,
+        )
+        return reconciled
 
     # ------------------------------------------------------------------
     # Model artifact execution (subprocess delegation)

--- a/views_pipeline_core/modules/validation/core_config_sniffer.py
+++ b/views_pipeline_core/modules/validation/core_config_sniffer.py
@@ -45,6 +45,9 @@ SUPPORTED_AGGREGATE_METHODS = frozenset({"arithmetic_mean"})
 # "pgm_cm_point" = the DataFrame ensemble path; "pgm_cm" = the frames-native PFE path
 # (point + probabilistic, mode auto-detected at runtime — epic #233).
 SUPPORTED_RECONCILIATION_TYPES = frozenset({"pgm_cm_point", "pgm_cm"})
+# Reconciliation types that require a CM model (`reconcile_with`). Explicit membership, not a
+# prefix match, so a future self-contained type can be supported without demanding reconcile_with.
+RECONCILIATION_TYPES_REQUIRING_CM = frozenset({"pgm_cm_point", "pgm_cm"})
 
 # Output scale — optional config key; declares whether model returns log-scale or natural-scale predictions
 SUPPORTED_OUTPUT_SCALES = frozenset({"log", "natural"})
@@ -313,8 +316,7 @@ class CoreConfigSniffer:
                 f"Supported: {sorted(SUPPORTED_RECONCILIATION_TYPES)}. "
                 f"Update SUPPORTED_RECONCILIATION_TYPES in core_config_sniffer.py when ready."
             )
-        # All pgm→cm reconciliation types (point or frames-native) require the CM model.
-        if recon.startswith("pgm_cm"):
+        if recon in RECONCILIATION_TYPES_REQUIRING_CM:
             recon_with = self._c.get("reconcile_with")
             if not recon_with:
                 raise ValueError(

--- a/views_pipeline_core/modules/validation/core_config_sniffer.py
+++ b/views_pipeline_core/modules/validation/core_config_sniffer.py
@@ -41,8 +41,10 @@ SUPPORTED_PREDICTION_FORMATS = frozenset({"dataframe", "prediction_frame"})
 SUPPORTED_EVALUATION_MODES  = frozenset({"stochastic", "point"})
 SUPPORTED_AGGREGATE_METHODS = frozenset({"arithmetic_mean"})
 
-# Reconciliation — optional config key; controls hierarchical prediction reconciliation
-SUPPORTED_RECONCILIATION_TYPES = frozenset({"pgm_cm_point"})
+# Reconciliation — optional config key; controls hierarchical prediction reconciliation.
+# "pgm_cm_point" = the DataFrame ensemble path; "pgm_cm" = the frames-native PFE path
+# (point + probabilistic, mode auto-detected at runtime — epic #233).
+SUPPORTED_RECONCILIATION_TYPES = frozenset({"pgm_cm_point", "pgm_cm"})
 
 # Output scale — optional config key; declares whether model returns log-scale or natural-scale predictions
 SUPPORTED_OUTPUT_SCALES = frozenset({"log", "natural"})
@@ -311,11 +313,12 @@ class CoreConfigSniffer:
                 f"Supported: {sorted(SUPPORTED_RECONCILIATION_TYPES)}. "
                 f"Update SUPPORTED_RECONCILIATION_TYPES in core_config_sniffer.py when ready."
             )
-        if recon == "pgm_cm_point":
+        # All pgm→cm reconciliation types (point or frames-native) require the CM model.
+        if recon.startswith("pgm_cm"):
             recon_with = self._c.get("reconcile_with")
             if not recon_with:
                 raise ValueError(
-                    "CoreConfigSniffer: reconciliation='pgm_cm_point' requires "
+                    f"CoreConfigSniffer: reconciliation='{recon}' requires "
                     "'reconcile_with' to specify the CM model for reconciliation. "
                     "Add reconcile_with to config_meta.py."
                 )


### PR DESCRIPTION
**Epic:** #233 · **Story S3** (#236) — the integration that turns the capability on. Depends on S1 (#234, reconcile_frames) + S2 (#235, cm loader), both merged.

## What
**PFE** (`prediction_frame_ensemble.py`):
- `_build_context`: removed the "refuse reconciliation" guard; reads `reconciliation` / `reconcile_with` from config into the context (were hardcoded `None`).
- `_forecast_ensemble`: after aggregation, before save, applies reconciliation when configured.
- New `_reconcile_forecast(agg_pf, target, ctx)`: **fail loud** if reconciliation is configured but no `Reconciler` was injected (`RECONCILER_NOT_INJECTED_MSG`, no silent-off); else `load_cm_frame(...)` → `reconcile_frames(...)`. Geography stays injected from views-models — pipeline-core builds no map.

**Sniffer** (`core_config_sniffer.py`):
- Added `"pgm_cm"` (frames-native path) to `SUPPORTED_RECONCILIATION_TYPES`; generalized the branch so any `pgm_cm*` type requires `reconcile_with`.

## Tests
New `TestPredictionFrameReconciliationWiring` (context reads config; fail-loud without reconciler; loader+port wiring via stubs — internals covered by S1/S2). Sniffer accept/reject for `pgm_cm`. Removed the obsolete refusal-guard characterization tests (superseded). DataFrame path (`pgm_cm_point`) regression-checked.

Local: `ruff` clean; reconciliation/ensemble/sniffer/domain suites green (246 passed across the touched areas).

🤖 Generated with [Claude Code](https://claude.com/claude-code)