### PR TITLE
S3 (#227) — MetricFrame faithfulness gate (parity + round-trip + provenance)

### DIFF
--- a/tests/test_managers/test_evaluation_stage.py
+++ b/tests/test_managers/test_evaluation_stage.py
@@ -15,16 +15,37 @@ from unittest.mock import MagicMock, patch
 import pandas as pd
 import pytest
 
-sys.modules["wandb"] = MagicMock()
-sys.modules["views_evaluation"] = MagicMock()
-sys.modules["views_evaluation.evaluation"] = MagicMock()
-sys.modules["views_evaluation.evaluation.evaluation_frame"] = MagicMock()
-sys.modules["art"] = MagicMock()
-
-from views_pipeline_core.managers.evaluation.stage import (  # noqa: E402
+from views_pipeline_core.managers.evaluation.stage import (
     EvaluationContext,
     EvaluationStage,
 )
+
+
+@pytest.fixture(autouse=True, scope="module")
+def _mock_optional_deps():
+    """Mock the heavy/optional deps the stage imports **lazily** (wandb, views_evaluation,
+    art) for this module's tests only, restoring sys.modules on teardown.
+
+    Module-scoped + restored so the mock never leaks into other test modules — e.g.
+    test_metric_frame_faithfulness.py needs the REAL views_evaluation. (Previously these were
+    permanent module-level sys.modules mutations that poisoned later modules.)
+    """
+    names = [
+        "wandb",
+        "views_evaluation",
+        "views_evaluation.evaluation",
+        "views_evaluation.evaluation.evaluation_frame",
+        "art",
+    ]
+    saved = {n: sys.modules.get(n) for n in names}
+    for n in names:
+        sys.modules[n] = MagicMock()
+    yield
+    for n, mod in saved.items():
+        if mod is None:
+            sys.modules.pop(n, None)
+        else:
+            sys.modules[n] = mod
 
 
 # ── Fixtures ─────────────────────────────────────────────────────────────────

--- a/tests/test_managers/test_metric_frame_faithfulness.py
+++ b/tests/test_managers/test_metric_frame_faithfulness.py
@@ -1,0 +1,114 @@
+"""#227 (epic #224) — MetricFrame faithfulness gate.
+
+Round-trip + parity (the ``group_id="mean"`` rows == the nanmean of the per-group legacy
+metrics — the value views-reporting reads) + provenance-presence, against the REAL
+views-evaluation / views-frames substrate, fully offline (a synthetic ``EvaluationReport`` —
+no wandb / viewser). Capability-skipped where the optional substrate is absent (PyPI-only CI).
+"""
+import numpy as np
+import pytest
+
+pytest.importorskip("views_frames")
+_er_mod = pytest.importorskip("views_evaluation.evaluation.evaluation_report")
+_mf_mod = pytest.importorskip("views_evaluation.evaluation.metric_frame")
+
+EvaluationReport = _er_mod.EvaluationReport
+MetricFrame = _mf_mod.MetricFrame
+MEAN_GROUP_ID = _mf_mod.MEAN_GROUP_ID
+SCHEMA_TO_EVAL_TYPE = _mf_mod.SCHEMA_TO_EVAL_TYPE
+
+if not hasattr(EvaluationReport, "to_metric_frame"):  # older views-evaluation
+    pytest.skip("views-evaluation predates to_metric_frame", allow_module_level=True)
+
+MONTH = SCHEMA_TO_EVAL_TYPE["month"]
+
+
+def _report():
+    # Two groups so the cross-group "mean" row is a non-trivial nanmean.
+    results = {
+        "month": {
+            "g1": {"MSE": 2.0, "MAE": 1.0},
+            "g2": {"MSE": 4.0, "MAE": 3.0},
+        },
+    }
+    return EvaluationReport(
+        target="lr_sb", task="regression", pred_type="point", results=results
+    )
+
+
+def _mf(**over):
+    kw = dict(model_id="my_model", run_type="calibration", partition="(1, 2)", level="pgm")
+    kw.update(over)
+    return _report().to_metric_frame(**kw)
+
+
+def _row_value(mf, *, eval_type, metric, group_id):
+    ids = mf.identifiers
+    mask = (
+        (ids["eval_type"] == eval_type)
+        & (ids["metric"] == metric)
+        & (ids["group_id"] == group_id)
+    )
+    idx = np.flatnonzero(mask)
+    assert idx.size == 1, f"expected exactly one row, got {idx.size}"
+    return float(mf.values[idx[0], 0])
+
+
+class TestParity:
+    def test_mean_rows_equal_nanmean_of_groups(self):
+        mf = _mf()
+        # nanmean(2,4)=3 ; nanmean(1,3)=2 — the rows views-reporting matches on.
+        assert _row_value(mf, eval_type=MONTH, metric="MSE", group_id=MEAN_GROUP_ID) == pytest.approx(3.0)
+        assert _row_value(mf, eval_type=MONTH, metric="MAE", group_id=MEAN_GROUP_ID) == pytest.approx(2.0)
+
+    def test_per_group_rows_preserved(self):
+        mf = _mf()
+        assert _row_value(mf, eval_type=MONTH, metric="MSE", group_id="g1") == pytest.approx(2.0)
+        assert _row_value(mf, eval_type=MONTH, metric="MSE", group_id="g2") == pytest.approx(4.0)
+
+    def test_values_are_float32_column_vector(self):
+        mf = _mf()
+        assert mf.values.dtype == np.float32
+        assert mf.values.ndim == 2 and mf.values.shape[1] == 1
+
+
+class TestRoundTrip:
+    def test_save_load_preserves_values_identifiers_metadata(self, tmp_path):
+        mf = _mf()
+        directory = tmp_path / "mf"
+        mf.save(directory)
+        loaded = MetricFrame.load(directory)
+
+        np.testing.assert_array_equal(loaded.values, mf.values)
+        assert set(loaded.identifiers) == set(mf.identifiers)
+        for axis in mf.identifiers:
+            np.testing.assert_array_equal(loaded.identifiers[axis], mf.identifiers[axis])
+        assert loaded.metadata.provenance.model == "my_model"
+        assert loaded.metadata.provenance.run_type == "calibration"
+
+    def test_round_trip_mean_value_stable(self, tmp_path):
+        directory = tmp_path / "mf"
+        _mf().save(directory)
+        loaded = MetricFrame.load(directory)
+        assert _row_value(loaded, eval_type=MONTH, metric="MSE", group_id=MEAN_GROUP_ID) == pytest.approx(3.0)
+
+
+class TestProvenance:
+    def test_generic_provenance_present(self):
+        p = _mf().metadata.provenance
+        assert p.model == "my_model"
+        assert p.run_type == "calibration"
+
+    def test_partition_and_level_are_constant_columns(self):
+        mf = _mf()
+        assert set(mf.identifiers["partition"].tolist()) == {"(1, 2)"}
+        assert set(mf.identifiers["level"].tolist()) == {"pgm"}
+
+    def test_scoring_code_version_defaulted(self):
+        assert _mf().metadata.scoring_code_version  # non-empty default (installed pkg version)
+
+    def test_run_id_and_data_version_none_until_s4(self):
+        # S2 emits partial provenance; run_id/data_version are plumbed in S4 (#228, C-110).
+        p = _mf().metadata.provenance
+        assert p.run_id is None
+        assert p.data_version is None


### PR DESCRIPTION
**Epic:** #224 · **Story S3** (#227). Test-only (+ a test-isolation fix). The faithfulness gate for the eval-of-record.

## What (new `tests/test_managers/test_metric_frame_faithfulness.py`)
Drives the **real** views-evaluation/views-frames substrate, fully offline (a synthetic `EvaluationReport`):
- **Parity:** the `group_id="mean"` rows == `nanmean` of the per-group metrics (the value views-reporting reads); per-group rows preserved; values are float32 `(N,1)`.
- **Round-trip:** `MetricFrame.save()`/`load()` preserves values, identifiers, provenance.
- **Provenance:** model/run_type in metadata; partition/level constant columns; `scoring_code_version` defaulted; `run_id`/`data_version` `None` until S4 (#228).
- Capability-skipped where the substrate is absent (PyPI-only CI).

## Test-isolation fix (surfaced by this work)
`test_evaluation_stage.py` set module-level `sys.modules[...] = MagicMock()` for wandb/views_evaluation/art — a permanent global mutation that poisoned later modules (the faithfulness test needs the **real** package). Since stage.py imports those **lazily**, the globals were never needed at import: scoped them to an autouse module fixture that restores `sys.modules` on teardown. Verified both files pass in **either** collection order.

## Notes
Local: `ruff` clean; 528 passed in test_managers. (4 pre-existing `test_reporting_stage` failures are local-env only — my editable views-reporting checkout is on the post-#173 branch where `templates.reports.evaluation` moved; they fail run-alone, file unchanged by me, and CI uses the pinned views-reporting.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)