### PR TITLE
S4 (#228) — MetricFrame provenance: run_id + data_version (closes C-110)

### DIFF
--- a/tests/test_managers/test_evaluation_stage.py
+++ b/tests/test_managers/test_evaluation_stage.py
@@ -486,10 +486,26 @@ class TestMetricFrameEmit:
         ctx = _make_context(configs=cfg, **over)
         ctx.model_path.data_generated = tmp_path
         ctx.model_path.model_name = "my_model"
+        if ctx.data_loader is not None:
+            ctx.data_loader.month_last = 540  # data-vintage marker (data_version, S4)
         return ctx
+
+    def test_provenance_none_when_no_active_run_or_loader(self, tmp_path):
+        # run_id None when no active WandB run; data_version None when no data_loader (S4).
+        stage = _make_stage()
+        stage._wandb_module.run_id = None
+        ctx = self._ctx(tmp_path, data_loader=None)
+        report = _make_mock_report()
+
+        stage._save_metric_frame(report, "lr_sb", ctx)
+
+        _, kwargs = report.to_metric_frame.call_args
+        assert kwargs["run_id"] is None
+        assert kwargs["data_version"] is None
 
     def test_emits_to_metric_frame_with_provenance_and_locked_path(self, tmp_path):
         stage = _make_stage()
+        stage._wandb_module.run_id = "run-abc"  # active WandB run (S4)
         ctx = self._ctx(tmp_path)
         report = _make_mock_report()
 
@@ -500,6 +516,8 @@ class TestMetricFrameEmit:
             run_type="calibration",
             partition=str(ctx.partition_dict["calibration"]),
             level="pgm",
+            run_id="run-abc",
+            data_version="540",
         )
         # CROSS-REPO CONTRACT: this path must equal views-reporting's
         # MetricFrameFileSource._frame_dir = root / model / run_type / metricframe_<target>

--- a/tests/test_managers/test_metric_frame_faithfulness.py
+++ b/tests/test_managers/test_metric_frame_faithfulness.py
@@ -107,8 +107,9 @@ class TestProvenance:
     def test_scoring_code_version_defaulted(self):
         assert _mf().metadata.scoring_code_version  # non-empty default (installed pkg version)
 
-    def test_run_id_and_data_version_none_until_s4(self):
-        # S2 emits partial provenance; run_id/data_version are plumbed in S4 (#228, C-110).
+    def test_omitted_provenance_defaults_to_none(self):
+        # to_metric_frame leaves run_id/data_version None when the caller omits them; the
+        # eval stage now supplies both (S4/#228), but the producer default is still None.
         p = _mf().metadata.provenance
         assert p.run_id is None
         assert p.data_version is None

--- a/tests/test_modules/test_wandb.py
+++ b/tests/test_modules/test_wandb.py
@@ -36,6 +36,15 @@ class TestWandBModule:
         assert module.models_path == Path("/models")
         assert module._active_run is None
 
+    def test_run_id_none_without_active_run(self, wandb_module):
+        """run_id is None when no run has been initialized (#228)."""
+        assert wandb_module.run_id is None
+
+    def test_run_id_returns_active_run_id(self, wandb_module):
+        """run_id surfaces the active run's id — the MetricFrame provenance discriminator (#228)."""
+        wandb_module._active_run = Mock(id="run-xyz")
+        assert wandb_module.run_id == "run-xyz"
+
     @patch('views_pipeline_core.modules.wandb.wandb.wandb.define_metric')
     @patch('views_pipeline_core.modules.wandb.wandb.wandb.init')
     def test_initialize_run(self, mock_init, mock_define_metric, wandb_module, mock_wandb_run):

--- a/views_pipeline_core/managers/evaluation/stage.py
+++ b/views_pipeline_core/managers/evaluation/stage.py
@@ -280,6 +280,17 @@ class EvaluationStage:
             return
 
         run_type = context.run_type
+        # Provenance (#228, closes C-110): run_id is the wrong-run discriminator (which WandB
+        # run produced this artifact); data_version marks the data vintage. data_version uses
+        # the loader's month_last — the available data-recency marker; a precise viewser
+        # snapshot id is a future refinement. Both may be None (no active run / no loader).
+        run_id = self._wandb_module.run_id if self._wandb_module is not None else None
+        data_version = (
+            str(context.data_loader.month_last)
+            if context.data_loader is not None
+            and getattr(context.data_loader, "month_last", None) is not None
+            else None
+        )
         metric_frame = report.to_metric_frame(
             model_id=context.model_path.model_name,
             run_type=run_type,
@@ -287,6 +298,8 @@ class EvaluationStage:
             # bug, consistent with _get_evaluation_step_mappings — never record "None".
             partition=str(context.partition_dict[run_type]),
             level=context.configs.get("level"),
+            run_id=run_id,
+            data_version=data_version,
         )
         frame_dir = (
             context.model_path.data_generated

--- a/views_pipeline_core/managers/evaluation/stage.py
+++ b/views_pipeline_core/managers/evaluation/stage.py
@@ -284,7 +284,8 @@ class EvaluationStage:
         # run produced this artifact); data_version marks the data vintage. data_version uses
         # the loader's month_last — the available data-recency marker; a precise viewser
         # snapshot id is a future refinement. Both may be None (no active run / no loader).
-        run_id = self._wandb_module.run_id if self._wandb_module is not None else None
+        # _wandb_module is always present here (_publish_results already used it above).
+        run_id = self._wandb_module.run_id
         data_version = (
             str(context.data_loader.month_last)
             if context.data_loader is not None

--- a/views_pipeline_core/modules/wandb/wandb.py
+++ b/views_pipeline_core/modules/wandb/wandb.py
@@ -23,6 +23,15 @@ class WandBModule:
         self.models_path = models_path
         self._active_run = None
 
+    @property
+    def run_id(self) -> Optional[str]:
+        """The active WandB run's id, or None if no run is initialized.
+
+        The provenance discriminator stamped onto the evaluation-of-record MetricFrame
+        (#228, closes C-110 — which run produced this artifact).
+        """
+        return self._active_run.id if self._active_run is not None else None
+
     def initialize_run(
         self,
         project: str,


### PR DESCRIPTION
**Epic:** #224 · **Story S4** (#228). Provenance — closes the C-48/C-110 wrong-run failure class.

## What
The eval-of-record MetricFrame now carries:
- **`run_id`** — new `WandBModule.run_id` property (active run's id, or `None`). This is the wrong-run **discriminator** (which WandB run produced the artifact) — the heart of C-110.
- **`data_version`** — `context.data_loader.month_last` (None when no loader).

Both threaded into `_save_metric_frame`'s `to_metric_frame(...)` call; both degrade to `None` cleanly (no active run / no loader).

## needs-decision resolved: data_version source
Picked **`data_loader.month_last`** — the readily-available data-recency marker (already used at `stage.py:320`). A precise **viewser snapshot id** would be more exact but isn't exposed on the loader; documented at the call site as a future refinement. `run_id` (not data_version) is the core of C-110, so this is sufficient to close it; the refinement is non-blocking.

## Tests
`WandBModule.run_id` (None / active id); stage emits `run_id` + `data_version`; both `None` when no active run / no loader; updated the S2 provenance assertion; renamed the faithfulness default-None test. `ruff` clean; 52 passed across the touched suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)