### PR TITLE
S5 (#229) — reporting consumes MetricFrame EvaluationSource; retire the WandB scrape

### DIFF
--- a/tests/test_managers/test_metric_frame_faithfulness.py
+++ b/tests/test_managers/test_metric_frame_faithfulness.py
@@ -93,6 +93,29 @@ class TestRoundTrip:
         assert _row_value(loaded, eval_type=MONTH, metric="MSE", group_id=MEAN_GROUP_ID) == pytest.approx(3.0)
 
 
+class TestCrossRepoPathContract:
+    """C-202 durable guard: the producer's save path (pipeline-core) must be exactly where
+    views-reporting's MetricFrameFileSource reads. Ties the producer prefix constant to the
+    real consumer loader, so a prefix/layout change on either side fails this round-trip."""
+
+    def test_producer_path_is_readable_by_metricframe_file_source(self, tmp_path):
+        sources = pytest.importorskip("views_reporting.sources")
+        from views_pipeline_core.managers.evaluation.stage import METRICFRAME_DIR_PREFIX
+
+        model, run_type, target = "my_model", "calibration", "lr_sb"
+        mf = _mf(model_id=model, run_type=run_type)
+        # Mirror EvaluationStage._save_metric_frame's layout: root/<model>/<run_type>/<prefix><target>
+        frame_dir = tmp_path / model / run_type / f"{METRICFRAME_DIR_PREFIX}{target}"
+        mf.save(frame_dir)
+
+        source = sources.MetricFrameFileSource(
+            root=tmp_path, run_type=run_type, target=target, primary_model=model
+        )
+        loaded = source.metric_frame(model)
+        assert loaded is not None, "consumer could not find the producer-written frame (path drift)"
+        np.testing.assert_array_equal(loaded.values, mf.values)
+
+
 class TestProvenance:
     def test_generic_provenance_present(self):
         p = _mf().metadata.provenance

--- a/tests/test_managers/test_reporting_stage.py
+++ b/tests/test_managers/test_reporting_stage.py
@@ -436,6 +436,25 @@ class TestEvaluationReport:
 
     @patch("views_reporting.templates.reports.evaluation.EvaluationReportTemplate")
     @patch("views_reporting.sources.MetricFrameFileSource")
+    def test_frame_load_error_propagates(
+        self, mock_source_cls, mock_template_cls,
+    ):
+        """A present-but-unreadable MetricFrame fails loud — not silently skipped or
+        degraded (Fail Loud; re-establishes the C-180 no-swallow contract for the
+        MetricFrame path, replacing the retired get_latest_run transient-error test).
+        Absent frame -> None -> skip; corrupt frame -> raise."""
+        stage = _make_stage()
+        ctx = _make_context()
+        mock_source_cls.return_value.metric_frame.side_effect = OSError("corrupt frame")
+
+        with pytest.raises(OSError):
+            stage.generate_evaluation_report(ctx)
+
+        mock_template_cls.assert_not_called()
+        stage._wandb_module.send_alert.assert_not_called()
+
+    @patch("views_reporting.templates.reports.evaluation.EvaluationReportTemplate")
+    @patch("views_reporting.sources.MetricFrameFileSource")
     def test_sends_wandb_alert_on_success(
         self, mock_source_cls, mock_template_cls,
     ):

--- a/tests/test_managers/test_reporting_stage.py
+++ b/tests/test_managers/test_reporting_stage.py
@@ -8,6 +8,7 @@ These tests verify that ReportingStage:
 4. Sends WandB alerts on success
 5. Raises appropriate errors for missing data
 """
+import importlib.util
 import sys
 from dataclasses import FrozenInstanceError
 from pathlib import Path
@@ -17,16 +18,54 @@ import pytest
 
 pytest.importorskip("views_reporting")
 
-sys.modules["wandb"] = MagicMock()
-sys.modules["views_evaluation"] = MagicMock()
-sys.modules["views_evaluation.evaluation"] = MagicMock()
-sys.modules["views_evaluation.evaluation.evaluation_frame"] = MagicMock()
-sys.modules["art"] = MagicMock()
+# The MetricFrame EvaluationSource consumer (views-reporting #173) may be absent in an older
+# released views-reporting; the source-based eval-report tests skip there (the producer epic
+# #224 integrates against the dev-installed consumer; publish is the final step).
+_HAS_EVAL_SOURCE = importlib.util.find_spec("views_reporting.sources") is not None
+if _HAS_EVAL_SOURCE:
+    # Cache views_reporting.sources (real) once so @patch("...MetricFrameFileSource") resolves.
+    # It imports views_evaluation.evaluation.metric_frame, but several other test modules poison
+    # sys.modules["views_evaluation*"] with MagicMocks at collection; temporarily restore the
+    # real package for this one import, then put their mocks back exactly as they were.
+    _ve_saved = {
+        k: sys.modules.pop(k)
+        for k in [
+            k for k in list(sys.modules)
+            if k == "views_evaluation" or k.startswith("views_evaluation.")
+        ]
+    }
+    try:
+        import views_reporting.sources  # noqa: F401
+    finally:
+        sys.modules.update(_ve_saved)
 
 from views_pipeline_core.managers.reporting.stage import (  # noqa: E402
     ReportingContext,
     ReportingStage,
 )
+
+
+@pytest.fixture(autouse=True, scope="module")
+def _mock_optional_deps():
+    """Mock heavy/optional deps the stage imports lazily (wandb, views_evaluation, art) for
+    this module's tests only, restoring sys.modules on teardown so the mocks never leak into
+    other modules (the reporting stage imports none of them at module load)."""
+    names = [
+        "wandb",
+        "views_evaluation",
+        "views_evaluation.evaluation",
+        "views_evaluation.evaluation.evaluation_frame",
+        "art",
+    ]
+    saved = {n: sys.modules.get(n) for n in names}
+    for n in names:
+        sys.modules[n] = MagicMock()
+    yield
+    for n, mod in saved.items():
+        if mod is None:
+            sys.modules.pop(n, None)
+        else:
+            sys.modules[n] = mod
 
 
 # ── Fixtures ─────────────────────────────────────────────────────────────────
@@ -326,54 +365,52 @@ class TestForecastReportPredictionFrame:
 # ── GREEN: Evaluation report ────────────────────────────────────────────────
 
 
+@pytest.mark.skipif(
+    not _HAS_EVAL_SOURCE,
+    reason="views-reporting lacks the EvaluationSource consumer (#173)",
+)
 class TestEvaluationReport:
-    """Verify evaluation report generation."""
+    """Eval report renders from the persisted MetricFrame via MetricFrameFileSource
+    (ADR-018 / C-108) — no render-time WandB scrape (the retired C-48/C-110 path)."""
 
-    @patch("views_pipeline_core.modules.wandb.get_latest_run")
-    @patch(
-        "views_reporting.templates.reports.evaluation.EvaluationReportTemplate"
-    )
-    def test_evaluation_report_calls_template_per_target(
-        self, mock_template_cls, mock_get_run,
+    @patch("views_reporting.templates.reports.evaluation.EvaluationReportTemplate")
+    @patch("views_reporting.sources.MetricFrameFileSource")
+    def test_renders_from_source_at_locked_path_per_target(
+        self, mock_source_cls, mock_template_cls,
     ):
-        """Must create one EvaluationReportTemplate per target."""
+        """One source + template per target; the source is built at the locked
+        cross-repo path (root=<data_generated>, primary_model=<model>)."""
         stage = _make_stage()
         ctx = _make_context(
-            configs={
-                "name": "test",
-                "targets": ["lr_sb", "lr_ns"],
-                "run_type": "calibration",
-            },
+            configs={"name": "test", "targets": ["lr_sb", "lr_ns"], "run_type": "calibration"},
         )
-
-        mock_get_run.return_value = MagicMock()
-        mock_template_cls.return_value.generate.return_value = Path(
-            "/tmp/eval_report.html"
-        )
+        ctx.model_path.data_generated = Path("/tmp/dg")
+        mock_source_cls.return_value.metric_frame.return_value = MagicMock()  # frame present
+        mock_template_cls.return_value.generate.return_value = Path("/tmp/eval_report.html")
 
         stage.generate_evaluation_report(ctx)
 
-        # Template instantiated twice — once per target
-        assert mock_template_cls.call_count == 2
-        # get_latest_run called with correct entity
-        mock_get_run.assert_called_once_with(
-            entity="views_pipeline",
-            model_name="test_model",
+        assert mock_source_cls.call_count == 2
+        mock_source_cls.assert_any_call(
+            root=Path("/tmp/dg"),
             run_type="calibration",
+            target="lr_sb",
+            primary_model="test_model",
+        )
+        assert mock_template_cls.call_count == 2
+        mock_template_cls.return_value.generate.assert_called_with(
+            source=mock_source_cls.return_value, target="lr_ns",
         )
 
-    @patch("views_pipeline_core.modules.wandb.get_latest_run")
-    @patch(
-        "views_reporting.templates.reports.evaluation.EvaluationReportTemplate"
-    )
-    def test_evaluation_report_skips_when_no_run(
-        self, mock_template_cls, mock_get_run,
+    @patch("views_reporting.templates.reports.evaluation.EvaluationReportTemplate")
+    @patch("views_reporting.sources.MetricFrameFileSource")
+    def test_skips_target_without_persisted_frame(
+        self, mock_source_cls, mock_template_cls,
     ):
-        """None from get_latest_run -> skip report, return None, do not crash (issue #177)."""
+        """No MetricFrame for the target -> skip it, render nothing, no alert."""
         stage = _make_stage()
         ctx = _make_context()
-
-        mock_get_run.return_value = None
+        mock_source_cls.return_value.metric_frame.return_value = None  # absent
 
         result = stage.generate_evaluation_report(ctx)
 
@@ -382,45 +419,33 @@ class TestEvaluationReport:
         stage._wandb_module.send_alert.assert_not_called()
 
     @patch("views_pipeline_core.modules.wandb.get_latest_run")
-    @patch(
-        "views_reporting.templates.reports.evaluation.EvaluationReportTemplate"
-    )
-    def test_evaluation_report_propagates_transient_error(
-        self, mock_template_cls, mock_get_run,
+    @patch("views_reporting.templates.reports.evaluation.EvaluationReportTemplate")
+    @patch("views_reporting.sources.MetricFrameFileSource")
+    def test_no_wandb_scrape_on_eval_path(
+        self, mock_source_cls, mock_template_cls, mock_get_run,
     ):
-        """Transient errors from get_latest_run must NOT be swallowed — they
-        propagate so a flaky fetch stays visible (issue #177, register C-180)."""
+        """The render-time get_latest_run scrape is retired (C-48/C-110)."""
         stage = _make_stage()
         ctx = _make_context()
+        mock_source_cls.return_value.metric_frame.return_value = MagicMock()
+        mock_template_cls.return_value.generate.return_value = Path("/tmp/eval_report.html")
 
-        mock_get_run.side_effect = ConnectionError("wandb unreachable")
+        stage.generate_evaluation_report(ctx)
 
-        with pytest.raises(ConnectionError):
-            stage.generate_evaluation_report(ctx)
+        mock_get_run.assert_not_called()
 
-        # A transient fetch error is exceptional, not a normal "no run" — the
-        # report must not be generated and no "success" alert must fire.
-        mock_template_cls.assert_not_called()
-        stage._wandb_module.send_alert.assert_not_called()
-
-    @patch("views_pipeline_core.modules.wandb.get_latest_run")
-    @patch(
-        "views_reporting.templates.reports.evaluation.EvaluationReportTemplate"
-    )
-    def test_evaluation_report_sends_wandb_alert(
-        self, mock_template_cls, mock_get_run,
+    @patch("views_reporting.templates.reports.evaluation.EvaluationReportTemplate")
+    @patch("views_reporting.sources.MetricFrameFileSource")
+    def test_sends_wandb_alert_on_success(
+        self, mock_source_cls, mock_template_cls,
     ):
-        """Evaluation report must send WandB alert on success."""
+        """Evaluation report sends a WandB alert when a report is rendered."""
         stage = _make_stage()
         ctx = _make_context()
-
-        mock_get_run.return_value = MagicMock()
-        mock_template_cls.return_value.generate.return_value = Path(
-            "/tmp/eval_report.html"
-        )
+        mock_source_cls.return_value.metric_frame.return_value = MagicMock()
+        mock_template_cls.return_value.generate.return_value = Path("/tmp/eval_report.html")
 
         stage.generate_evaluation_report(ctx)
 
         stage._wandb_module.send_alert.assert_called_once()
-        call_kwargs = stage._wandb_module.send_alert.call_args[1]
-        assert "Evaluation Report Generated" in call_kwargs["title"]
+        assert "Evaluation Report Generated" in stage._wandb_module.send_alert.call_args[1]["title"]

--- a/views_pipeline_core/managers/reporting/stage.py
+++ b/views_pipeline_core/managers/reporting/stage.py
@@ -7,7 +7,8 @@ ReportingContext rather than reaching into a parent class's internals.
 
 Responsibilities:
   - Load historical + forecast data for forecast reports
-  - Fetch latest WandB run for evaluation reports
+  - Render evaluation reports from the persisted MetricFrame via an injected
+    EvaluationSource (ADR-018 / C-108) — not a render-time WandB scrape
   - Delegate to ForecastReportTemplate / EvaluationReportTemplate
   - Publish completion alerts via WandB
 """
@@ -73,7 +74,8 @@ class ReportingContext(BaseStageContext):
     Extends BaseStageContext (configs, model_path, run_type) with
     reporting-specific fields.
     """
-    entity: str  # WandB entity (forecast-report alerts; no longer used by the eval path)
+    entity: str  # WandB entity; set at wandb.init() upstream. No stage method reads it now
+    # (the eval path retired get_latest_run); retained for call-site/back-compat.
     prediction_format: str = "dataframe"
 
 

--- a/views_pipeline_core/managers/reporting/stage.py
+++ b/views_pipeline_core/managers/reporting/stage.py
@@ -47,6 +47,25 @@ def _require_dense_report_consumer() -> None:
         ) from e
 
 
+def _require_evaluation_source_consumer() -> None:
+    """Fail loud if the installed views-reporting lacks the MetricFrame ``EvaluationSource``
+    consumer (ADR-018 / C-108, views-reporting #173) — the typed eval-of-record report path
+    this stage now requires. Mirrors :func:`_require_dense_report_consumer` (C-190): probe a
+    public capability with an actionable remediation rather than letting an ImportError
+    surface deep in report generation.
+    """
+    try:
+        from views_reporting.sources import MetricFrameFileSource  # noqa: F401
+    except ImportError as e:
+        raise RuntimeError(
+            "The installed views-reporting lacks the MetricFrame EvaluationSource consumer "
+            "('views_reporting.sources.MetricFrameFileSource'). The evaluation report now "
+            "renders from the persisted MetricFrame (ADR-018 / C-108), not a render-time "
+            "WandB scrape. Upgrade views-reporting to a build with EvaluationSource (#173). "
+            f"Underlying import error: {e}"
+        ) from e
+
+
 @dataclass(frozen=True)
 class ReportingContext(BaseStageContext):
     """Immutable context for report generation.
@@ -54,7 +73,7 @@ class ReportingContext(BaseStageContext):
     Extends BaseStageContext (configs, model_path, run_type) with
     reporting-specific fields.
     """
-    entity: str  # WandB entity for get_latest_run(), e.g. "views_pipeline"
+    entity: str  # WandB entity (forecast-report alerts; no longer used by the eval path)
     prediction_format: str = "dataframe"
 
 
@@ -163,52 +182,59 @@ class ReportingStage:
         return report_path
 
     def generate_evaluation_report(self, context: ReportingContext) -> Optional[Path]:
-        """Fetch latest WandB run, generate HTML evaluation report per target.
+        """Generate HTML evaluation report(s) from the persisted MetricFrame(s).
+
+        Renders from the typed evaluation-of-record MetricFrame via an injected
+        ``MetricFrameFileSource`` (ADR-018 / C-108) — **not** a render-time WandB scrape
+        (``get_latest_run``), which was the C-48/C-110 wrong-run failure class. One report
+        per target; a target with no persisted frame is skipped (its eval may have been
+        capability-skipped or not run).
 
         Args:
             context: Frozen ReportingContext with configuration, paths, run type.
 
         Returns:
-            Path to the last generated HTML report file.
+            Path to the last generated HTML report, or None if nothing was rendered.
         """
-        from views_pipeline_core.modules.wandb import get_latest_run
+        _require_evaluation_source_consumer()
+        from views_reporting.sources import MetricFrameFileSource
         from views_reporting.templates.reports.evaluation import (
             EvaluationReportTemplate,
         )
-
-        latest_run = get_latest_run(
-            entity=context.entity,
-            model_name=context.model_path.model_name,
-            run_type=context.run_type,
-        )
-        # get_latest_run returns None when the run is genuinely absent (no cloud
-        # project, or no finished metrics-bearing run — see issue #177). The
-        # downstream template dereferences wandb_run.summary unconditionally, so
-        # we degrade here rather than crash. Transient errors are NOT swallowed:
-        # they propagate from get_latest_run so a flaky fetch stays visible.
-        if latest_run is None:
-            logger.warning(
-                f"No finished WandB run with metrics found for "
-                f"{context.model_path.model_name} ({context.run_type}); "
-                f"skipping evaluation report generation."
-            )
-            return None
 
         targets = context.configs["targets"]
         if not targets:
             logger.warning("No targets configured — skipping evaluation report generation.")
             return None
 
+        model_name = context.model_path.model_name
         report_path = None
         for target in targets:
+            # LOCKED cross-repo path contract (C-202): root=<data_generated> matches the
+            # producer's <data_generated>/<model>/<run_type>/metricframe_<target> layout
+            # (EvaluationStage._save_metric_frame ↔ MetricFrameFileSource._frame_dir).
+            source = MetricFrameFileSource(
+                root=context.model_path.data_generated,
+                run_type=context.run_type,
+                target=target,
+                primary_model=model_name,
+            )
+            if source.metric_frame(model_name) is None:
+                logger.warning(
+                    "No MetricFrame for %s (%s, target=%s) at the eval-of-record path; "
+                    "skipping evaluation report for this target.",
+                    model_name, context.run_type, target,
+                )
+                continue
             evaluation_template = EvaluationReportTemplate(
                 config=context.configs,
                 model_path=context.model_path,
                 run_type=context.run_type,
             )
-            report_path = evaluation_template.generate(
-                wandb_run=latest_run, target=target,
-            )
+            report_path = evaluation_template.generate(source=source, target=target)
+
+        if report_path is None:
+            return None
 
         self._wandb_module.send_alert(
             title="Evaluation Report Generated",


### PR DESCRIPTION
**Epic:** #224 · **Story S5** (#229). The **consumer switch** — completes the evaluation-of-record loop and retires the C-48/C-110 wrong-run scrape.

## What
`ReportingStage.generate_evaluation_report` now renders from the **persisted MetricFrame** via views-reporting's `MetricFrameFileSource` (ADR-018 / C-108):
- Constructs `MetricFrameFileSource(root=<data_generated>, run_type, target, primary_model)` — the **locked path** matching the producer (C-202) — and calls `EvaluationReportTemplate.generate(source=..., target=...)`.
- **Retires `get_latest_run`** on the eval path (the render-time WandB scrape = the wrong-run failure class).
- A target with no persisted frame is **skipped** (graceful, like the old no-run skip).
- `_require_evaluation_source_consumer()` fails loud with remediation if views-reporting predates the consumer (#173) — mirrors `_require_dense_report_consumer` (C-190).

## Cross-repo (publish-last)
Runs today against the **dev-installed** views-reporting (#173 branch). For released CI/production, views-reporting must ship a release with #173 — **filed views-reporting#179** (no code touched there). Source-based eval tests capability-skip where `views_reporting.sources` is absent.

## Tests
- Rewrote `TestEvaluationReport` for the source flow: per-target + **locked-path** source construction, skip-without-frame, **no-scrape** assertion, alert-on-success.
- **C-202 durable guard** (faithfulness file): a cross-repo round-trip tying the producer's `METRICFRAME_DIR_PREFIX` to the real `MetricFrameFileSource` loader — fails if either path drifts.
- Scoped this file's leaking module-level `views_evaluation`/`wandb`/`art` mocks to a restoring fixture; surgical real-import of `views_reporting.sources` at collection so `@patch` resolves despite other modules' module-level mocks.

Local: `ruff` clean; **533 passed** in `test_managers`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)