### PR TITLE
feat(dataloaders): normalize priogrid_gid→priogrid_id at one seam (consolidation PR-2)

### DIFF
--- a/reports/technical_risk_register.md
+++ b/reports/technical_risk_register.md
@@ -1,8 +1,8 @@
 # Technical Risk Register
 
-**Last updated:** 2026-06-28
+**Last updated:** 2026-06-29
 **Governing ADR:** ADR-044 (Technical Risk Register)
-**Entry count:** 202 concerns (111 resolved) + 40 disagreements — 5 relocated to views-reporting
+**Entry count:** 203 concerns (111 resolved) + 40 disagreements — 5 relocated to views-reporting
 
 > **Strategic context (2026-06-19) — `views-frames` is coming.** A new leaf
 > data-contract package, `views_platform/views-frames` (scaffolded 2026-06-19,
@@ -67,6 +67,7 @@ is the trap C-36's DANGER note prevents.**
 
 | ID | Tier | Description | Trigger | Source | Status |
 |----|------|-------------|---------|--------|--------|
+| C-203 | 3 | **Raw-cache readers bypass the dataloader grid-name normalization seam.** `_normalize_grid_index` (`dataloaders.py`) normalizes `priogrid_gid`→`priogrid_id` only on the `get_data` fetch + cache-read path. `evaluation/stage.py:161` (`_load_actuals`) and `reporting/stage.py:156/281/304` call `read_dataframe` on the raw cache directly, so in a transitional state where an old on-disk cache still carries `priogrid_gid` (not re-fetched), actuals/historical carry `gid` while predictions carry the canonical `id`. Masked in-repo (`pd.Index.equals` ignores names); the real exposure is cross-repo name-sensitive alignment (views-evaluation/views-reporting adapters). Self-closes as caches are re-fetched; the durable fix routes those reads through the loader or normalizes `read_dataframe`. Introduced by consolidation PR-2; revisit in PR-3 or a follow-up. | When an old `priogrid_gid` cache is evaluated/reported without re-fetching and feeds name-sensitive cross-repo alignment | review (PR-2 priogrid_id consolidation) | Open |
 | C-01 | 3 | **God class: ForecastingModelManager (substantially mitigated, DOWNGRADED from Tier 2).** All 6 ADR-045 extractions complete: E1 (PredictionIOManager), E2 (EvaluationStage), E3 (ReportingStage), E4 (ForecastingStage), E5 (TrainingStage), E6 (ModelPathManager relocation to `data/model_path.py`). `model.py` reduced from 3049 to ~1960 LOC. Root Cause #1 (inverted dependencies) resolved — lower layers now import from `data/` not `managers/`. Remaining: abstract method context parameters; WandB lifecycle template; Pipeline composition container. Clean Architecture audit (2026-04-08) confirmed remaining ISP concern — stages can reach back through mutable references passed at construction (C-45). | When a new stage extraction (E7+) is attempted, verify it follows the ADR-045 frozen context pattern — reach-back through mutable references would re-cement coupling | repo-assimilation + expert-code-review | Open |
 | C-03 | 3 | **Ensemble data coupling — first model assumed authoritative (DOWNGRADED from Tier 2).** `evaluation/stage.py:135` hardcodes `ModelPathManager(context.configs["models"][0]).data_raw` to load actuals. `validate_ensemble_raw_data_alignment()` added (2026-04-04) to detect inconsistent raw data across models via file size comparison. The hardcoded `[0]` access remains but misalignment is now detectable. | Ensemble models have genuinely different querysets (different file sizes) but validation not called before evaluation | C-03 investigation | Open |
 | C-05 | 4 | **Class-level mutable state in ModelPathManager (DOWNGRADED from Tier 1 → 3 → 4).** `data/model_path.py:77` declares `_root = None` at class level, set once via lazy init, never reset. Theoretical risk only — every production run operates from a single project root per process. No observed or reproducible scenario. | Hypothetical multi-project tool or test that creates instances from different roots without process isolation | C-05 investigation | Accepted |

--- a/tests/test_modules/test_core_data_sniffer.py
+++ b/tests/test_modules/test_core_data_sniffer.py
@@ -29,7 +29,7 @@ def _pgm_df(first: int, last: int) -> pd.DataFrame:
     months = list(range(first, last + 1))
     idx = pd.MultiIndex.from_arrays(
         [[100] * len(months), months],
-        names=["priogrid_gid", "month_id"],
+        names=["priogrid_id", "month_id"],
     )
     return pd.DataFrame({"value": np.zeros(len(months))}, index=idx)
 
@@ -64,12 +64,18 @@ class TestMultiIndexStructure:
         with pytest.raises(ValueError, match="flat index"):
             CoreDataSniffer(calibration_partition, "calibration", level="pgm").sniff_loaded_data(df)
 
+    def test_legacy_grid_name_accepted_transitionally(self, calibration_partition):
+        """priogrid_id is canonical; the legacy priogrid_gid is still accepted (ADR-015)."""
+        df = _pgm_df(121, 444)  # same valid frame as the happy path...
+        df.index = df.index.set_names(["priogrid_gid", "month_id"])  # ...but legacy name
+        CoreDataSniffer(calibration_partition, "calibration", level="pgm").sniff_loaded_data(df)
+
     def test_wrong_index_name_pgm_raises(self, calibration_partition):
-        """priogrid_id (legacy) is NOT accepted; priogrid_gid is canonical."""
+        """A non-grid entity name (neither priogrid_id nor the legacy alias) is rejected."""
         months = [121, 122]
         idx = pd.MultiIndex.from_arrays(
             [[100, 100], months],
-            names=["priogrid_id", "month_id"],
+            names=["grid_cell", "month_id"],
         )
         df = pd.DataFrame({"value": [0.0, 0.0]}, index=idx)
         with pytest.raises(ValueError, match="do not match"):
@@ -98,7 +104,7 @@ class TestMultiIndexStructure:
             CoreDataSniffer(calibration_partition, "calibration", level="pgm").sniff_loaded_data(df)
 
     def test_cm_level_rejects_pgm_index(self, calibration_partition):
-        """cm level must reject a pgm-format DataFrame (priogrid_gid/month_id)."""
+        """cm level must reject a pgm-format DataFrame (priogrid_id/month_id)."""
         df = _pgm_df(121, 444)
         with pytest.raises(ValueError, match="do not match"):
             CoreDataSniffer(calibration_partition, "calibration", level="cm").sniff_loaded_data(df)

--- a/tests/test_modules/test_core_prediction_sniffer.py
+++ b/tests/test_modules/test_core_prediction_sniffer.py
@@ -52,13 +52,25 @@ class TestSniffPredictionsPass:
 # ---------------------------------------------------------------------------
 
 class TestBehaviorChanges:
-    def test_priogrid_id_index_raises(self):
-        """priogrid_id is legacy — only priogrid_gid is canonical."""
+    def test_grid_names_accepted_canonical_and_legacy(self):
+        """priogrid_id is canonical (ADR-015); the legacy priogrid_gid is still accepted."""
+        for entity in ("priogrid_id", "priogrid_gid"):
+            df = pd.DataFrame(
+                {"pred_ged_sb": [0.1, 0.2, 0.3]},
+                index=pd.MultiIndex.from_tuples(
+                    [(100, 480), (101, 481), (102, 482)],
+                    names=[entity, "month_id"],
+                ),
+            )
+            CorePredictionSniffer(level="pgm").sniff_predictions(df, "ged_sb")
+
+    def test_non_grid_entity_name_raises(self):
+        """A name that is neither priogrid_id nor the legacy alias is rejected."""
         df = pd.DataFrame(
             {"pred_ged_sb": [0.1, 0.2, 0.3]},
             index=pd.MultiIndex.from_tuples(
                 [(100, 480), (101, 481), (102, 482)],
-                names=["priogrid_id", "month_id"],
+                names=["grid_cell", "month_id"],
             ),
         )
         with pytest.raises(ValueError, match="do not match"):

--- a/tests/test_modules/test_grid_index_normalization.py
+++ b/tests/test_modules/test_grid_index_normalization.py
@@ -1,0 +1,96 @@
+"""Grid-entity name consolidation seam (views-frames ADR-015): `priogrid_gid → priogrid_id`.
+
+Covers `_normalize_grid_index` (the single dataloader seam) and the transitional
+accept-both behavior of `CoreDataSniffer._check_multiindex`. PR-2 of the consolidation:
+the seam normalizes; the sniffer still tolerates the legacy name until PR-3 flips it id-only.
+"""
+import numpy as np
+import pandas as pd
+import pytest
+
+from views_pipeline_core.modules.dataloaders.dataloaders import _normalize_grid_index
+from views_pipeline_core.modules.validation.core_data_sniffer import _check_multiindex
+
+
+def _pgm_df(entity_name, n_months=3, n_ent=4, seed=0):
+    rng = np.random.default_rng(seed)
+    months = np.repeat(np.arange(100, 100 + n_months), n_ent)
+    ents = np.tile(np.arange(1, n_ent + 1), n_months)
+    idx = pd.MultiIndex.from_arrays([months, ents], names=["month_id", entity_name])
+    return pd.DataFrame({"pred_sb": rng.uniform(0, 5, size=len(months))}, index=idx)
+
+
+# --------------------------------------------------------------------- _normalize_grid_index
+
+
+def test_normalize_renames_gid_to_id():
+    out = _normalize_grid_index(_pgm_df("priogrid_gid"))
+    assert out.index.names == ["month_id", "priogrid_id"]
+
+
+def test_normalize_idempotent_on_canonical():
+    df = _pgm_df("priogrid_id")
+    out = _normalize_grid_index(df)
+    assert out.index.names == ["month_id", "priogrid_id"]
+
+
+def test_normalize_leaves_cm_untouched():
+    df = _pgm_df("country_id")
+    out = _normalize_grid_index(df)
+    assert out.index.names == ["month_id", "country_id"]
+
+
+def test_normalize_passthrough_non_multiindex():
+    flat = pd.DataFrame({"a": [1, 2]})  # flat index
+    assert _normalize_grid_index(flat) is flat
+
+
+def test_normalize_passthrough_none():
+    assert _normalize_grid_index(None) is None
+
+
+def test_normalize_both_names_fails_loud():
+    """A frame carrying both grid names is ambiguous — fail loud, don't make a duplicate level."""
+    idx = pd.MultiIndex.from_arrays(
+        [[100], [100], [121]], names=["priogrid_gid", "priogrid_id", "month_id"]
+    )
+    df = pd.DataFrame({"v": [0.0]}, index=idx)
+    with pytest.raises(ValueError, match="both"):
+        _normalize_grid_index(df)
+
+
+def test_normalize_is_pure_rename_value_identical():
+    """The legacy→canonical change is a NAME change only — values and (time, entity)
+    pairs are bit-identical (guards against gid vs id ever meaning different data)."""
+    gid = _pgm_df("priogrid_gid", seed=7)
+    before_vals = gid["pred_sb"].to_numpy(copy=True)
+    before_pairs = list(zip(gid.index.get_level_values(0), gid.index.get_level_values(1)))
+
+    out = _normalize_grid_index(gid)
+
+    np.testing.assert_array_equal(out["pred_sb"].to_numpy(), before_vals)
+    after_pairs = list(zip(out.index.get_level_values(0), out.index.get_level_values(1)))
+    assert after_pairs == before_pairs
+    assert out.index.names[1] == "priogrid_id"  # only the name moved
+
+
+def test_normalize_gid_parquet_roundtrip(tmp_path):
+    """A legacy gid-named parquet on disk normalizes to canonical on read-back."""
+    path = tmp_path / "calibration_viewser_df.parquet"
+    _pgm_df("priogrid_gid", seed=3).to_parquet(path)
+    out = _normalize_grid_index(pd.read_parquet(path))
+    assert out.index.names == ["month_id", "priogrid_id"]
+
+
+# --------------------------------------------------------------------- sniffer accept-both
+
+
+@pytest.mark.parametrize("entity_name", ["priogrid_id", "priogrid_gid"])
+def test_sniffer_accepts_both_grid_names(entity_name):
+    # Transitional: both the canonical and the legacy grid name pass structure validation.
+    _check_multiindex(_pgm_df(entity_name), level="pgm", source="Test")
+
+
+def test_sniffer_rejects_wrong_grid_name():
+    with pytest.raises(ValueError, match="do not match"):
+        _check_multiindex(_pgm_df("country_id"), level="pgm", source="Test")

--- a/tests/test_modules/test_synthetic_dispatch.py
+++ b/tests/test_modules/test_synthetic_dispatch.py
@@ -94,7 +94,7 @@ class TestFetchFromSynthetic:
         df, alerts = loader._fetch_data_from_synthetic(self_test=False)
         assert isinstance(df, pd.DataFrame)
         assert isinstance(df.index, pd.MultiIndex)
-        assert list(df.index.names) == ["month_id", "priogrid_gid"]
+        assert list(df.index.names) == ["month_id", "priogrid_id"]
 
     def test_returns_alerts_none(self, loader):
         _, alerts = loader._fetch_data_from_synthetic(self_test=False)

--- a/tests/test_modules/test_synthetic_generator.py
+++ b/tests/test_modules/test_synthetic_generator.py
@@ -66,7 +66,7 @@ class TestGenerateSyntheticData:
     def test_returns_dataframe_with_correct_multiindex_pgm(self, vertical_descriptor):
         df = generate_synthetic_data(vertical_descriptor, month_first=445, month_last=448)
         assert isinstance(df.index, pd.MultiIndex)
-        assert list(df.index.names) == ["month_id", "priogrid_gid"]
+        assert list(df.index.names) == ["month_id", "priogrid_id"]
 
     def test_feature_columns_match_descriptor(self, vertical_descriptor):
         df = generate_synthetic_data(vertical_descriptor, month_first=445, month_last=448)
@@ -91,7 +91,7 @@ class TestGenerateSyntheticData:
         df = generate_synthetic_data(vertical_descriptor, month_first=445, month_last=448)
         assert "row" in df.columns
         assert "col" in df.columns
-        gids = df.index.get_level_values("priogrid_gid")
+        gids = df.index.get_level_values("priogrid_id")
         expected_row = ((gids - 1) // _PRIOGRID_NCOL + 1).astype(float)
         expected_col = ((gids - 1) % _PRIOGRID_NCOL + 1).astype(float)
         pd.testing.assert_series_equal(
@@ -135,13 +135,13 @@ class TestGenerateSyntheticData:
             "seed": 42,
         }
         df = generate_synthetic_data(desc, month_first=445, month_last=446)
-        n_entities = df.index.get_level_values("priogrid_gid").nunique()
+        n_entities = df.index.get_level_values("priogrid_id").nunique()
         assert n_entities == DEFAULT_N_ENTITIES_PGM
 
     def test_custom_entity_count(self, vertical_descriptor):
         vertical_descriptor["n_entities"] = 50
         df = generate_synthetic_data(vertical_descriptor, month_first=445, month_last=446)
-        n_entities = df.index.get_level_values("priogrid_gid").nunique()
+        n_entities = df.index.get_level_values("priogrid_id").nunique()
         assert n_entities == 50
 
     def test_total_rows_equals_months_times_entities(self, vertical_descriptor):
@@ -179,7 +179,7 @@ class TestVerticalStripePattern:
 
     def test_pattern_static_across_time(self, vertical_descriptor):
         df = generate_synthetic_data(vertical_descriptor, month_first=445, month_last=448)
-        entity_1_vals = df.xs(1, level="priogrid_gid")["synth_target"]
+        entity_1_vals = df.xs(1, level="priogrid_id")["synth_target"]
         assert entity_1_vals.nunique() == 1
 
 
@@ -211,7 +211,7 @@ class TestHorizontalStripePattern:
 
     def test_pattern_static_across_time(self, horizontal_descriptor):
         df = generate_synthetic_data(horizontal_descriptor, month_first=445, month_last=448)
-        entity_1_vals = df.xs(1, level="priogrid_gid")["synth_target"]
+        entity_1_vals = df.xs(1, level="priogrid_id")["synth_target"]
         assert entity_1_vals.nunique() == 1
 
 
@@ -233,7 +233,7 @@ class TestDiagonalGradientPattern:
 
     def test_pattern_static_across_time(self, diagonal_descriptor):
         df = generate_synthetic_data(diagonal_descriptor, month_first=445, month_last=448)
-        entity_1_vals = df.xs(1, level="priogrid_gid")["synth_target"]
+        entity_1_vals = df.xs(1, level="priogrid_id")["synth_target"]
         assert entity_1_vals.nunique() == 1
 
 

--- a/views_pipeline_core/modules/dataloaders/dataloaders.py
+++ b/views_pipeline_core/modules/dataloaders/dataloaders.py
@@ -33,6 +33,38 @@ _LOA_TO_OUTPUT_FORMAT = {
     "country_month": "country_month",
 }
 
+#: Grid-entity index-name consolidation (views-frames ADR-015). RAW sources (viewser,
+#: datafactory's legacy pandas path, synthetic) still emit the legacy ``priogrid_gid``;
+#: ``_normalize_grid_index`` is the single seam that rewrites it to the canonical
+#: ``priogrid_id`` so the on-disk cache and every downstream consumer see one name.
+#: Remove this seam (and its call sites in ``_fetch_data`` / ``get_data``) once all
+#: sources emit ``priogrid_id`` natively.
+_LEGACY_GRID_ID = "priogrid_gid"
+_CANONICAL_GRID_ID = "priogrid_id"
+
+
+def _normalize_grid_index(df: Optional[pd.DataFrame]) -> Optional[pd.DataFrame]:
+    """Rename a legacy ``priogrid_gid`` index level to the canonical ``priogrid_id``.
+
+    No-op when the level is absent or already canonical, or when ``df`` is not a MultiIndex
+    frame. Renames the index only (no data copy); callers own the frame they pass in.
+    """
+    if df is None or not isinstance(df.index, pd.MultiIndex):
+        return df
+    names = list(df.index.names)
+    if _LEGACY_GRID_ID in names and _CANONICAL_GRID_ID in names:
+        # A frame carrying BOTH names is malformed; renaming would create two levels
+        # named priogrid_id (duplicate). Fail loud rather than silently corrupt.
+        raise ValueError(
+            f"DataFrame index carries both '{_LEGACY_GRID_ID}' and '{_CANONICAL_GRID_ID}' "
+            f"levels: {names}. Cannot normalize an ambiguous grid index."
+        )
+    if _LEGACY_GRID_ID in names:
+        df.index = df.index.set_names(
+            [_CANONICAL_GRID_ID if n == _LEGACY_GRID_ID else n for n in names]
+        )
+    return df
+
 # Ingester dependent imports. Breaks tests on github because no certs
 def _get_splag_country(*args, **kwargs):
     import views_transformation_library.splag_country as splag_country
@@ -1198,8 +1230,14 @@ class ViewsDataLoader:
         if feature_rename:
             df = df.rename(columns=feature_rename)
 
-        if loa == "priogrid_month" and "priogrid_gid" in df.index.names:
-            pgids = df.index.get_level_values("priogrid_gid")
+        # Resolve the grid level by alias, not a hardcoded literal, so this still derives
+        # row/col when datafactory emits the canonical priogrid_id (this runs before the
+        # _fetch_data normalization seam). See _LEGACY_GRID_ID / _CANONICAL_GRID_ID.
+        _grid_level = next(
+            (n for n in df.index.names if n in (_LEGACY_GRID_ID, _CANONICAL_GRID_ID)), None
+        )
+        if loa == "priogrid_month" and _grid_level is not None:
+            pgids = df.index.get_level_values(_grid_level)
             if "row" not in df.columns:
                 df["row"] = ((pgids - 1) // _PRIOGRID_NCOL + 1).astype(float)
             if "col" not in df.columns:
@@ -1293,16 +1331,20 @@ class ViewsDataLoader:
             ValueError: If source is not recognized.
         """
         if source == "viewser":
-            return self._fetch_data_from_viewser(self_test)
+            df, alerts = self._fetch_data_from_viewser(self_test)
         elif source == "datafactory":
-            return self._fetch_data_from_datafactory(self_test)
+            df, alerts = self._fetch_data_from_datafactory(self_test)
         elif source == "synthetic":
-            return self._fetch_data_from_synthetic(self_test)
+            df, alerts = self._fetch_data_from_synthetic(self_test)
         else:
             raise ValueError(
                 f"Unknown data source '{source}' for model {self._model_name}. "
                 f"Expected 'viewser', 'datafactory', or 'synthetic'."
             )
+        # Single normalization seam: every RAW source funnels through here, so the cache
+        # written by get_data() and all downstream consumers carry the canonical
+        # priogrid_id (views-frames ADR-015). See _normalize_grid_index.
+        return _normalize_grid_index(df), alerts
 
     def _get_month_range(self) -> tuple[int, int]:
         """
@@ -1498,6 +1540,9 @@ class ViewsDataLoader:
             if path_cached_df.exists():
                 try:
                     df = read_dataframe(path_cached_df)
+                    # Upgrade legacy caches written before the consolidation: an on-disk
+                    # priogrid_gid cache is normalized to priogrid_id on read (ADR-015).
+                    df = _normalize_grid_index(df)
                     logger.info(f"Reading saved data from {path_cached_df}")
                 except Exception as e:
                     raise RuntimeError(

--- a/views_pipeline_core/modules/dataloaders/synthetic.py
+++ b/views_pipeline_core/modules/dataloaders/synthetic.py
@@ -60,7 +60,7 @@ def generate_synthetic_data(
         month_last: Last month_id (inclusive).
 
     Returns:
-        DataFrame with MultiIndex [month_id, priogrid_gid],
+        DataFrame with MultiIndex [month_id, priogrid_id],
         feature columns, and derived row/col columns. All float64.
 
     Raises:
@@ -107,7 +107,7 @@ def generate_synthetic_data(
 
     index = pd.MultiIndex.from_arrays(
         [all_month_ids, all_entity_ids],
-        names=["month_id", "priogrid_gid"],
+        names=["month_id", "priogrid_id"],
     )
 
     tiled_values = np.tile(base_values, n_months)

--- a/views_pipeline_core/modules/validation/core_data_sniffer.py
+++ b/views_pipeline_core/modules/validation/core_data_sniffer.py
@@ -13,14 +13,24 @@ import pandas as pd
 
 logger = logging.getLogger(__name__)
 
-# Canonical MultiIndex layouts for RAW VIEWSER data (before dataset construction).
-# Uses priogrid_gid because CoreDataSniffer audits data BEFORE the _PGDataset
-# rename boundary (see ADR-034). Downstream code uses priogrid_id.
+# Canonical MultiIndex layouts for RAW data. The grid entity is the canonical
+# ``priogrid_id`` (views-frames ADR-015); the dataloader normalizes the legacy
+# ``priogrid_gid`` to it at a single seam before this audit runs.
 # Extend these constants (not inline checks) when new levels are added.
 EXPECTED_INDEX_NAMES: Dict[str, tuple] = {
-    "pgm": ("priogrid_gid", "month_id"),
-    "cm":  ("country_id",   "month_id"),
+    "pgm": ("priogrid_id", "month_id"),
+    "cm":  ("country_id",  "month_id"),
 }
+
+# Transitional: a grid frame may still carry the legacy name (an old on-disk cache, or a
+# source not yet normalized). Treat both as the canonical name for structure validation.
+# Remove this alias (id-only) once the legacy name is fully retired (consolidation PR-3).
+_GRID_ID_ALIASES = frozenset({"priogrid_gid", "priogrid_id"})
+
+
+def _canonical_index_name(name: str) -> str:
+    """Map a legacy grid-entity name to its canonical form; pass other names through."""
+    return "priogrid_id" if name in _GRID_ID_ALIASES else name
 
 # Partition dict structural keys — internal; not part of the public API.
 _PARTITION_TRAIN = "train"
@@ -44,15 +54,16 @@ def _check_multiindex(df: pd.DataFrame, level: str, source: str) -> None:
             f"Supported layouts: {list(EXPECTED_INDEX_NAMES.values())}."
         )
 
-    actual = set(df.index.names)
-
     if level not in EXPECTED_INDEX_NAMES:
         raise NotImplementedError(
             f"{source}: level='{level}' is not supported. "
             f"Supported: {list(EXPECTED_INDEX_NAMES)}. "
             f"Update EXPECTED_INDEX_NAMES in core_data_sniffer.py when ready."
         )
-    expected = set(EXPECTED_INDEX_NAMES[level])
+    # Canonicalize the grid-entity name on both sides so the legacy priogrid_gid still
+    # passes transitionally (see _GRID_ID_ALIASES).
+    actual = {_canonical_index_name(n) for n in df.index.names}
+    expected = {_canonical_index_name(n) for n in EXPECTED_INDEX_NAMES[level]}
     if actual != expected:
         raise ValueError(
             f"{source}: MultiIndex names {tuple(df.index.names)} do not match "


### PR DESCRIPTION
PR-2 of the platform `priogrid_gid → priogrid_id` consolidation (canonical name per views-frames ADR-015). Replaces three scattered late renames with a single normalization seam at the data loader, so caches and all downstream consumers see one name.

## What changed
- **`dataloaders.py`** — `_normalize_grid_index(df)` seam, applied in `_fetch_data` (fresh caches → `priogrid_id`) and on the `use_saved` cache-read path (old `gid` caches upgraded on read). Fail-loud if a frame carries *both* names.
- **`synthetic.py`** — emits `priogrid_id` directly.
- **`core_data_sniffer.py`** — `EXPECTED_INDEX_NAMES["pgm"]` → `priogrid_id`, with a transitional `_GRID_ID_ALIASES` so the legacy `gid` still passes (shared by data + prediction sniffers). Flips to id-only in PR-3.
- **datafactory row/col derivation** made name-agnostic (was keyed on the literal `priogrid_gid` before the seam).
- The late renames (`_PGDataset`, ensemble `_ENTITY_RENAME`) and the aggregator defensive accept are **intentionally left as no-ops** — deleted in PR-3.

## Verification
- New `test_grid_index_normalization.py` (pure-function cases, **value-identity guard**, `gid`-parquet roundtrip, both-names fail-loud, sniffer accept-both); updated sniffer + synthetic tests.
- Full-suite delta vs `development`: **zero new failures** (remaining failures are pre-existing views-reporting `calculate_hdi` import drift, unrelated — proved by a stash baseline).
- **End-to-end:** the synthetic ensemble dry-run (`synthetic_chant`) that this duality previously blocked now runs green — 3/3 constituents aggregated, no OOM, CRPS through month 504.

## Review (`/review`, addressed)
- Fixed: both-names ambiguity (fail-loud guard); datafactory derivation keyed on the legacy literal (now alias-based).
- Deferred + registered as **C-203**: evaluation/reporting read the raw cache directly, bypassing the seam — a transitional mixed-cache name mismatch (masked in-repo; cross-repo alignment exposure). Self-closes as caches refresh; durable fix in a follow-up.

## Coordination
No cross-repo blocker: views-hydranet reads the cache name-agnostically on its `development` (views-hydranet#145/#144). PR-3 (delete renames + flip sniffer to id-only) follows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)