### PR TITLE
Ensemble aggregator new new

### DIFF
--- a/tests/test_modules/test_ensemble_aggregator.py
+++ b/tests/test_modules/test_ensemble_aggregator.py
@@ -5,11 +5,11 @@ import pyarrow as pa
 import pyarrow.parquet as pq
 import pytest
 
-from views_pipeline_core.modules.aggregation.aggregator import (
+from views_pipeline_core.modules.aggregation.aggregation import (
     AggregationModule,
     _ModelSpec,
 )
-from views_pipeline_core.modules.aggregation.aggregator import (
+from views_pipeline_core.modules.aggregation.aggregation import (
     _arrow_series_to_numpy,
 )
 
@@ -818,7 +818,9 @@ class TestAddModelParquetDispatch:
         )
 
         with (
-            patch.object(AggregationModule, "_load_parquet_direct", return_value=dummy_df) as mock_direct,
+            patch.object(
+                AggregationModule, "_load_parquet_direct", return_value=dummy_df
+            ) as mock_direct,
             patch.object(AggregationModule, "_load_to_polars") as mock_legacy,
         ):
             mgr.add_model(data=path, name="m1")
@@ -841,7 +843,9 @@ class TestAddModelParquetDispatch:
         )
 
         with (
-            patch.object(AggregationModule, "_load_to_polars", return_value=dummy_df) as mock_legacy,
+            patch.object(
+                AggregationModule, "_load_to_polars", return_value=dummy_df
+            ) as mock_legacy,
             patch.object(AggregationModule, "_load_parquet_direct") as mock_direct,
         ):
             mgr.add_model(data=csv_path, name="m1")
@@ -860,7 +864,9 @@ class TestAddModelParquetDispatch:
         )
 
         with (
-            patch.object(AggregationModule, "_load_to_polars", return_value=dummy_df) as mock_legacy,
+            patch.object(
+                AggregationModule, "_load_to_polars", return_value=dummy_df
+            ) as mock_legacy,
             patch.object(AggregationModule, "_load_parquet_direct") as mock_direct,
         ):
             mgr.add_model(data=pdf, name="m1")
@@ -869,8 +875,12 @@ class TestAddModelParquetDispatch:
 
     def test_end_to_end_parquet_aggregation(self, tmp_path):
         """Two Arrow parquets → add_model both → aggregate() → correct shape and values."""
-        path1 = _make_arrow_parquet(tmp_path, "m1.parquet", n_rows=3, n_samples=2, value=1.0)
-        path2 = _make_arrow_parquet(tmp_path, "m2.parquet", n_rows=3, n_samples=2, value=3.0)
+        path1 = _make_arrow_parquet(
+            tmp_path, "m1.parquet", n_rows=3, n_samples=2, value=1.0
+        )
+        path2 = _make_arrow_parquet(
+            tmp_path, "m2.parquet", n_rows=3, n_samples=2, value=3.0
+        )
 
         mgr = AggregationModule(
             index_cols=["month_id", "country_id"],

--- a/views_pipeline_core/managers/ensemble/ensemble.py
+++ b/views_pipeline_core/managers/ensemble/ensemble.py
@@ -20,7 +20,7 @@ from views_pipeline_core.configs.pipeline import PipelineConfig
 from views_pipeline_core.data.handlers import _PGDataset, _CDataset, _ViewsDataset
 from views_pipeline_core.domain.reconciliation_port import Reconciler, RECONCILER_NOT_INJECTED_MSG
 from views_pipeline_core.exceptions import PipelineException
-from views_pipeline_core.modules.aggregation.aggregator import (
+from views_pipeline_core.modules.aggregation.aggregation import (
     AggregationModule,
 )
 

--- a/views_pipeline_core/modules/aggregation/__init__.py
+++ b/views_pipeline_core/modules/aggregation/__init__.py
@@ -1,1 +1,4 @@
-from .aggregator import AggregationModule as AggregationModule, _ModelSpec as _ModelSpec
+from .aggregation import (
+    AggregationModule as AggregationModule,
+    _ModelSpec as _ModelSpec,
+)

--- a/views_pipeline_core/modules/aggregation/aggregation.py
+++ b/views_pipeline_core/modules/aggregation/aggregation.py
@@ -390,6 +390,8 @@ class AggregationModule:
 
         pooled_cols = []
         rng = np.random.default_rng(42)
+        chosen_models = rng.choice(self.n_models, size=n_samples, p=weights)
+        chosen_samples = rng.integers(n_samples, size=n_samples)
 
         for target_column in self.target_cols:
 
@@ -417,17 +419,10 @@ class AggregationModule:
             n_rows, n_models, n_samples_check = model_stack.shape
             assert n_samples_check == n_samples
 
-            # Draw model indices and sample indices for ALL rows at once
-            # model_idx: (n_rows, n_samples) with values in [0, n_models)
-            model_idx = rng.choice(n_models, size=(n_rows, n_samples), p=weights)
-            # sample_idx: (n_rows, n_samples) with values in [0, n_samples)
-            sample_idx = rng.integers(n_samples, size=(n_rows, n_samples))
-
-            # row indices broadcasted to (n_rows, n_samples)
-            row_idx = np.arange(n_rows)[:, None]
-
-            # Advanced indexing: result shape (n_rows, n_samples)
-            pooled_array = model_stack[row_idx, model_idx, sample_idx]
+            # Draw one model and one sample column for each ensemble sample.
+            # The chosen model/sample pair is reused across all rows and all targets,
+            # preserving the joint covariance structure.
+            pooled_array = model_stack[:, chosen_models, chosen_samples]
 
             # Convert each row to a list
             pooled_lists = pooled_array.tolist()


### PR DESCRIPTION
Following a discussion with Mike, we agreed that probabilistic aggregation should be performed globally rather than blockwise (e.g., per grid cell or country) to preserve the joint dependence across countries. This only affects linear pooling (_concatenate function). As well, a couple of file names were changed to align better with our current structure