### PR TITLE
feat(pfe): Hop-A Track A publish leg — sampled forecasts reach the prediction store (#269)

### DIFF
--- a/tests/test_managers/test_sampled_forecast_publisher.py
+++ b/tests/test_managers/test_sampled_forecast_publisher.py
@@ -1,0 +1,279 @@
+"""#269 / ADR-013 §3 — the Hop-A Track A publish leg.
+
+Covers the amended #269 acceptance criteria: (a) §3.4 emission assert, (b) §3.3
+golden-string names, (c) §10.2 injectable provenance + byte-pinned header, (d) §2 header
+content incl. the §7a wire-target mapping, (e) round-trip identity (archive → load_pf),
+(f) manifest-last commit protocol + torn-run abort, (g) flag gating on the PFE.
+"""
+import json
+import zipfile
+from pathlib import Path
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+from views_frames import PredictionFrame, SpatialLevel, SpatioTemporalIndex
+
+from views_pipeline_core.managers.ensemble.prediction_frame_ensemble import (
+    PredictionFrameEnsembleManager,
+)
+from views_pipeline_core.managers.ensemble.sampled_forecast_publisher import (
+    INTERNAL_TO_WIRE_TARGET,
+    MANIFEST_NAME_TEMPLATE,
+    MANIFEST_TYPE,
+    SHARD_NAME_TEMPLATE,
+    SHARD_TYPE,
+    WIRE_CONTRACT_VERSION,
+    _assert_staged_emission,
+    build_header,
+    header_bytes,
+    publish_sampled_forecast,
+    wire_target,
+)
+from views_pipeline_core.managers.prediction.prediction_frame_io import load_pf, save_pf
+
+
+def _pf(times, n_cells=4, n_samples=8, seed=0):
+    rng = np.random.default_rng(seed)
+    time = np.repeat(np.asarray(times, dtype=np.int64), n_cells)
+    unit = np.tile(np.arange(1, n_cells + 1, dtype=np.int64), len(times))
+    return PredictionFrame(
+        rng.uniform(0, 5, size=(len(time), n_samples)).astype(np.float32),
+        SpatioTemporalIndex(time, unit, SpatialLevel.PGM),
+    )
+
+
+class _FakeDatastore:
+    """Records uploads in order; copies file bytes (the real tempdir dies after publish)."""
+
+    def __init__(self, fail_on: str | None = None):
+        self.uploads = []
+        self._fail_on = fail_on
+
+    def upload_data(self, *, file, filename, loa, name, type, targets, category,
+                    description=None):
+        if self._fail_on and self._fail_on in filename:
+            return SimpleNamespace(success=False, error="synthetic failure", data={})
+        self.uploads.append(
+            {"filename": filename, "name": name, "type": type, "loa": loa,
+             "targets": list(targets), "category": category,
+             "bytes": Path(file).read_bytes()}
+        )
+        return SimpleNamespace(success=True, data={"file_id": f"fid-{len(self.uploads)}"})
+
+
+def _publish(store, pf, **overrides):
+    kwargs = dict(
+        ensemble_name="rusty_bucket",
+        internal_target="lr_sb_best",
+        run_id="rusty_bucket_forecasting_20260715_000000",
+        level="pgm",
+        reconciled=True,
+        generated_at="2026-07-15T00:00:00+00:00",
+        pipeline_core_version="3.0.0",
+    )
+    kwargs.update(overrides)
+    return publish_sampled_forecast(store, pf, **kwargs)
+
+
+# ------------------------------------------------------------------ (b) golden strings
+
+
+def test_shard_name_golden_string():
+    assert (
+        SHARD_NAME_TEMPLATE.format(run_id="r1", target="lr_ged_sb", time_id=543)
+        == "r1__lr_ged_sb__m000543.tap.zip"
+    )
+
+
+def test_manifest_name_golden_string():
+    assert (
+        MANIFEST_NAME_TEMPLATE.format(run_id="r1", target="lr_ged_sb")
+        == "r1__lr_ged_sb__manifest.json"
+    )
+
+
+# ------------------------------------------------------------------ (d) §7a wire mapping
+
+
+def test_wire_target_mapping():
+    assert wire_target("lr_sb_best") == "lr_ged_sb"
+    assert wire_target("lr_ns_best") == "lr_ged_ns"
+    assert wire_target("lr_os_best") == "lr_ged_os"
+    assert set(INTERNAL_TO_WIRE_TARGET.values()) == {"lr_ged_sb", "lr_ged_ns", "lr_ged_os"}
+
+
+def test_wire_target_unmapped_fails_loud():
+    with pytest.raises(ValueError, match="wire-name mapping"):
+        wire_target("synth_target")
+
+
+# ------------------------------------------------------------------ (c) byte-pinned header
+
+
+def test_header_bytes_are_stable_given_injected_provenance():
+    header = build_header(
+        sample_count=8, spatial_level="pgm", target_wire="lr_ged_sb", time_id=543,
+        run_id="r1", generated_at="2026-07-15T00:00:00+00:00", ensemble_name="rusty_bucket",
+        reconciled=True, shard_index=0, shard_count=2, pipeline_core_version="3.0.0",
+    )
+    expected = (
+        "{\n"
+        '  "contract_version": "' + WIRE_CONTRACT_VERSION + '",\n'
+        '  "frame_type": "prediction",\n'
+        '  "representation": "samples",\n'
+        '  "sample_count": 8,\n'
+        '  "dtype": "float32",\n'
+        '  "spatial_level": "pgm",\n'
+        '  "target": "lr_ged_sb",\n'
+        '  "time_id": 543,\n'
+        '  "run_id": "r1",\n'
+        '  "generated_at": "2026-07-15T00:00:00+00:00",\n'
+        '  "id_semantics": {\n'
+        '    "time": "views_month_id",\n'
+        '    "unit": "priogrid_id"\n'
+        "  },\n"
+        '  "provenance": {\n'
+        '    "ensemble": "rusty_bucket",\n'
+        '    "pipeline_core_version": "3.0.0",\n'
+        '    "reconciled": true\n'
+        "  },\n"
+        '  "sharding": {\n'
+        '    "scheme": "per_month",\n'
+        '    "index": 0,\n'
+        '    "count": 2\n'
+        "  }\n"
+        "}\n"
+    ).encode("utf-8")
+    assert header_bytes(header) == expected
+
+
+# ------------------------------------------------------------------ (e)+(f) publish flow
+
+
+def test_publish_uploads_shards_then_manifest_last():
+    store = _FakeDatastore()
+    pf = _pf(times=[543, 544], n_samples=8)
+    manifest = _publish(store, pf)
+
+    assert len(store.uploads) == 3  # 2 shards + 1 manifest
+    assert [u["type"] for u in store.uploads] == [SHARD_TYPE, SHARD_TYPE, MANIFEST_TYPE]
+    assert store.uploads[-1]["filename"].endswith("__manifest.json")
+    # store-document fields (§3.1)
+    for u in store.uploads:
+        assert u["category"] == "forecast"
+        assert u["loa"] == "pgm"
+        assert u["targets"] == ["lr_ged_sb"]
+    # manifest content (§3.2)
+    assert manifest["contract_version"] == WIRE_CONTRACT_VERSION
+    assert manifest["expected_months"] == [543, 544]
+    assert manifest["expected_cell_count"] == 4
+    assert manifest["sidecar_sha256"] is None
+    assert [s["time_id"] for s in manifest["shards"]] == [543, 544]
+    assert all(s["file_id"] for s in manifest["shards"])
+
+
+def test_round_trip_identity_archive_to_load_pf(tmp_path):
+    store = _FakeDatastore()
+    pf = _pf(times=[543, 544], n_samples=8, seed=7)
+    _publish(store, pf)
+
+    shard = store.uploads[0]
+    zpath = tmp_path / shard["filename"]
+    zpath.write_bytes(shard["bytes"])
+    out = tmp_path / "unpacked"
+    with zipfile.ZipFile(zpath) as zf:
+        assert sorted(zf.namelist()) == ["identifiers.npz", "metadata.json", "y_pred.npy"]
+        zf.extractall(out)
+
+    loaded = load_pf(out, level="pgm")
+    times = np.asarray(pf.index.time)
+    month_pf = pf.select(times == 543)
+    np.testing.assert_array_equal(loaded.values, month_pf.values)
+    np.testing.assert_array_equal(
+        np.asarray(loaded.index.unit), np.asarray(month_pf.index.unit)
+    )
+    header = json.loads((out / "metadata.json").read_text())
+    assert header["sample_count"] == 8
+    assert header["sharding"] == {"scheme": "per_month", "index": 0, "count": 2}
+
+
+def test_shard_failure_withholds_manifest():
+    store = _FakeDatastore(fail_on="m000544")  # second shard fails
+    pf = _pf(times=[543, 544])
+    with pytest.raises(RuntimeError, match="manifest is withheld"):
+        _publish(store, pf)
+    assert all(u["type"] == SHARD_TYPE for u in store.uploads)  # no manifest committed
+
+
+def test_ragged_months_fail_loud():
+    # month 544 carries fewer cells than 543 → malformed run, no publish
+    pf = _pf(times=[543, 544])
+    times = np.asarray(pf.index.time)
+    keep = ~((times == 544) & (np.asarray(pf.index.unit) == 1))
+    ragged = pf.select(keep)
+    with pytest.raises(ValueError, match="differing cell counts"):
+        _publish(_FakeDatastore(), ragged)
+
+
+# ------------------------------------------------------------------ (a) §3.4 assert
+
+
+def test_emission_assert_trips_on_corrupted_stage(tmp_path):
+    pf = _pf(times=[543])
+    times = np.asarray(pf.index.time)
+    month_pf = pf.select(times == 543)
+    save_pf(month_pf, tmp_path)
+    _assert_staged_emission(tmp_path, month_pf, agg_sample_count=8)  # clean passes
+
+    np.save(tmp_path / "y_pred.npy", np.zeros((4, 8), dtype=np.float64))  # wrong dtype
+    with pytest.raises(ValueError, match="dtype"):
+        _assert_staged_emission(tmp_path, month_pf, agg_sample_count=8)
+
+    np.save(tmp_path / "y_pred.npy", np.zeros((4, 5), dtype=np.float32))  # wrong S
+    with pytest.raises(ValueError, match="sample_count"):
+        _assert_staged_emission(tmp_path, month_pf, agg_sample_count=8)
+
+
+# ------------------------------------------------------------------ (g) PFE wiring
+
+
+def _bare_manager(use_store: bool) -> PredictionFrameEnsembleManager:
+    m = object.__new__(PredictionFrameEnsembleManager)
+    m._use_prediction_store = use_store
+    m._datastore = _FakeDatastore()
+    return m
+
+
+def test_pfe_publish_method_routes_context(monkeypatch):
+    calls = {}
+
+    def fake_publish(datastore, agg_pf, **kwargs):
+        calls.update(kwargs)
+        return {}
+
+    import views_pipeline_core.managers.ensemble.sampled_forecast_publisher as sfp
+    monkeypatch.setattr(sfp, "publish_sampled_forecast", fake_publish)
+
+    m = _bare_manager(use_store=True)
+    ctx = SimpleNamespace(
+        configs={"name": "rusty_bucket", "level": "pgm"},
+        run_type="forecasting",
+        timestamp="20260715_000000",
+        reconciliation="pgm_cm",
+    )
+    m._publish_sampled_forecast(_pf(times=[543]), "lr_sb_best", ctx)
+
+    assert calls["ensemble_name"] == "rusty_bucket"
+    assert calls["internal_target"] == "lr_sb_best"
+    assert calls["run_id"] == "rusty_bucket_forecasting_20260715_000000"
+    assert calls["level"] == "pgm"
+    assert calls["reconciled"] is True
+
+
+def test_pfe_datastore_starts_unbuilt():
+    # The leg is opt-in: no datastore is constructed at init (env credentials are only
+    # required when use_prediction_store is actually exercised).
+    import inspect
+    src = inspect.getsource(PredictionFrameEnsembleManager.__init__)
+    assert "_datastore = None" in src

--- a/views_pipeline_core/managers/ensemble/prediction_frame_ensemble.py
+++ b/views_pipeline_core/managers/ensemble/prediction_frame_ensemble.py
@@ -152,6 +152,7 @@ class PredictionFrameEnsembleManager:
         self._ensemble_path = ensemble_path
         self._wandb_notifications = wandb_notifications
         self._use_prediction_store = use_prediction_store
+        self._datastore = None  # built lazily by _build_datastore (#269)
         # Accepted for uniform composition-root injection; PFE has no point
         # reconciliation path yet (probabilistic PFE reconciliation is #200).
         self._reconciler = reconciler
@@ -592,8 +593,46 @@ class PredictionFrameEnsembleManager:
             )
             save_pf(agg_pf, save_dir)
             forecasts[target] = agg_pf
+            if self._use_prediction_store:
+                # #269 / ADR-013 §3: the Hop-A publish leg — Track A archives +
+                # manifest-last, per (run, target). Runs only under the flag; child
+                # runs never reach here with it set (prediction_store=False forcing).
+                self._publish_sampled_forecast(agg_pf, target, ctx)
 
         return forecasts
+
+    def _publish_sampled_forecast(
+        self, agg_pf: PredictionFrame, target: str, ctx: EnsembleContext
+    ) -> None:
+        """Publish one (run, target) to the prediction store (ADR-013 §3, #269)."""
+        from views_pipeline_core.managers.ensemble.sampled_forecast_publisher import (
+            publish_sampled_forecast,
+        )
+
+        publish_sampled_forecast(
+            self._build_datastore(),
+            agg_pf,
+            ensemble_name=ctx.configs["name"],
+            internal_target=target,
+            run_id=f"{ctx.configs['name']}_{ctx.run_type}_{ctx.timestamp}",
+            level=ctx.configs["level"],
+            reconciled=bool(ctx.reconciliation),
+        )
+
+    def _build_datastore(self):
+        """Lazily construct the store uploader (same pattern as model.py's publish path:
+        `PredictionStoreConfig.from_environment()` fails loud on missing credentials)."""
+        if self._datastore is None:
+            from views_pipeline_core.configs.prediction_store import PredictionStoreConfig
+            from views_pipeline_core.modules.datastore import DatastoreModule
+
+            config = PredictionStoreConfig.from_environment()
+            self._datastore = DatastoreModule(
+                appwrite_file_manager_config=config.to_appwrite_config(
+                    self._ensemble_path
+                )
+            )
+        return self._datastore
 
     def _reconcile_forecast(
         self, agg_pf: PredictionFrame, target: str, ctx: EnsembleContext

--- a/views_pipeline_core/managers/ensemble/sampled_forecast_publisher.py
+++ b/views_pipeline_core/managers/ensemble/sampled_forecast_publisher.py
@@ -1,0 +1,325 @@
+"""Hop-A publish leg: the Track A archive (#269; ADR-013 §3 — the Sampled-Forecast Wire
+Contract, adopted 2026-07-15 as views-postprocessing `docs/ADRs/013_...md`, contract v1.5).
+
+`PredictionFrameEnsembleManager` saves each aggregated forecast locally (`save_pf` →
+`y_pred.npy` + `identifiers.npz`); until #269 no code path carried those pooled draws to the
+prediction store. This module is that leg: per **(run, target, month)** it stages exactly what
+PFE already writes, adds the §2 contract header (`metadata.json`), zips, and uploads — then
+uploads the per-(run, target) **manifest last** as the commit marker (§3.2: consumers MUST
+ignore unmanifested shards, so a killed run leaves no visible state).
+
+A free-function module the manager calls (epic #233 pattern — keeps the publish leg testable
+without constructing the PFE, and keeps that class from growing). Zero new serialization:
+the shard payload is byte-for-byte the local Track A layout (§3.1), wrapped.
+
+Contract obligations implemented here:
+  * §3.4 emission assert — staged files (pre-zip) must match the frame handed in; the zip
+    step itself is covered by the round-trip test (#269 acceptance (e)).
+  * §3.3 naming — templates are shared constants; the name is a locator only, identity is
+    manifest content + the embedded header (the C-59/C-94 lesson).
+  * §7a — the single internal→wire target mapping (`lr_ged_sb/ns/os`); unmapped targets
+    fail loud rather than leak internal vocabulary onto the wire.
+  * §10.2 — `run_id`/`generated_at` are injectable for byte-stable fixture parity.
+  * §3.2 note — the manifest's `sidecar_sha256` is ``null``: the §5 sidecar is produced
+    downstream (views-postprocessing); the Hop-A producer has no sidecar artifact to hash.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import tempfile
+import zipfile
+from datetime import datetime, timezone
+from importlib.metadata import PackageNotFoundError, version
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+import numpy as np
+from views_frames import PredictionFrame
+
+from views_pipeline_core.managers.prediction.prediction_frame_io import save_pf
+
+logger = logging.getLogger(__name__)
+
+#: ADR-013 §2 — the contract version this producer stamps on every header.
+WIRE_CONTRACT_VERSION = "1.5"
+
+#: ADR-013 §3.1 / §3.2 — store-document ``type`` vocabulary (disjoint from the legacy
+#: ``model``/``ensemble`` types by design; §11.4 minimal-guard note).
+SHARD_TYPE = "sampled_forecast_shard"
+MANIFEST_TYPE = "sampled_forecast_manifest"
+FORECAST_CATEGORY = "forecast"
+
+#: ADR-013 §3.3 — name templates. Shared constants with golden-string tests; the name is a
+#: locator only. Consumers MUST NOT parse identity out of it.
+SHARD_NAME_TEMPLATE = "{run_id}__{target}__m{time_id:06d}.tap.zip"
+MANIFEST_NAME_TEMPLATE = "{run_id}__{target}__manifest.json"
+
+#: ADR-013 §7a — THE internal→wire target mapping (one shared constant, cited by the golden
+#: fixture). Wire vocabulary is canonical `lr_ged_*`; no `_best` on a draws wire.
+INTERNAL_TO_WIRE_TARGET: Dict[str, str] = {
+    "lr_sb_best": "lr_ged_sb",
+    "lr_ns_best": "lr_ged_ns",
+    "lr_os_best": "lr_ged_os",
+}
+
+
+def wire_target(internal_target: str) -> str:
+    """Map an internal target name to the canonical wire vocabulary (§7a). Fail loud on
+    unmapped names — internal vocabulary must never leak onto the wire."""
+    try:
+        return INTERNAL_TO_WIRE_TARGET[internal_target]
+    except KeyError:
+        raise ValueError(
+            f"No wire-name mapping for internal target '{internal_target}'. "
+            f"ADR-013 §7a requires the canonical wire vocabulary "
+            f"({sorted(INTERNAL_TO_WIRE_TARGET.values())}); extend "
+            f"INTERNAL_TO_WIRE_TARGET deliberately — do not publish internal names."
+        ) from None
+
+
+def _pipeline_core_version() -> str:
+    """Self-reported version for the §2 provenance caveat (wrong until the release train
+    (#261) cuts real releases — consumers must not treat it as authoritative)."""
+    try:
+        return version("views_pipeline_core")
+    except PackageNotFoundError:  # editable/dev edge case
+        return "unknown"
+
+
+def build_header(
+    *,
+    sample_count: int,
+    spatial_level: str,
+    target_wire: str,
+    time_id: int,
+    run_id: str,
+    generated_at: str,
+    ensemble_name: str,
+    reconciled: bool,
+    shard_index: int,
+    shard_count: int,
+    pipeline_core_version: Optional[str] = None,
+) -> Dict[str, Any]:
+    """The §2 shared contract header, key order exactly as the ADR-013 example (the golden
+    fixture pins the serialized bytes; order is part of byte-parity)."""
+    return {
+        "contract_version": WIRE_CONTRACT_VERSION,
+        "frame_type": "prediction",
+        "representation": "samples",
+        "sample_count": sample_count,
+        "dtype": "float32",
+        "spatial_level": spatial_level,
+        "target": target_wire,
+        "time_id": time_id,
+        "run_id": run_id,
+        "generated_at": generated_at,
+        "id_semantics": {"time": "views_month_id", "unit": "priogrid_id"},
+        "provenance": {
+            "ensemble": ensemble_name,
+            "pipeline_core_version": (
+                pipeline_core_version
+                if pipeline_core_version is not None
+                else _pipeline_core_version()
+            ),
+            "reconciled": reconciled,
+        },
+        "sharding": {"scheme": "per_month", "index": shard_index, "count": shard_count},
+    }
+
+
+def header_bytes(header: Dict[str, Any]) -> bytes:
+    """Serialize the §2 header. One serializer for every emission — this is what makes the
+    byte-pinned fixture meaningful (§10)."""
+    return (json.dumps(header, indent=2) + "\n").encode("utf-8")
+
+
+def _assert_staged_emission(
+    stage_dir: Path, month_pf: PredictionFrame, agg_sample_count: int
+) -> None:
+    """ADR-013 §3.4 — the producer-side mechanism guard, against the STAGED files pre-zip.
+
+    Each hop vouches for its own emission: the staged bytes must match the frame this leg was
+    handed. The FAO policy (S_min, collapse detection) lives downstream at the §6 boundary —
+    knowledge locality forbids asserting it here.
+    """
+    y = np.load(stage_dir / "y_pred.npy")
+    if y.ndim != 2 or y.shape[1] != agg_sample_count:
+        raise ValueError(
+            f"§3.4 emission assert failed at {stage_dir}: staged y_pred has shape "
+            f"{y.shape}, expected (N, {agg_sample_count}) — the staged draws do not match "
+            f"the aggregated frame's sample_count."
+        )
+    if y.dtype != np.float32:
+        raise ValueError(
+            f"§3.4 emission assert failed at {stage_dir}: staged dtype {y.dtype}, "
+            f"expected float32 (ADR-013 §2/§3.1)."
+        )
+    if y.shape[0] != month_pf.n_rows:
+        raise ValueError(
+            f"§3.4 emission assert failed at {stage_dir}: staged N={y.shape[0]}, "
+            f"expected {month_pf.n_rows} rows for this month shard."
+        )
+    with np.load(stage_dir / "identifiers.npz") as ids:
+        for key, expected in month_pf.identifiers.items():
+            if not np.array_equal(ids[key], expected):
+                raise ValueError(
+                    f"§3.4 emission assert failed at {stage_dir}: staged identifier "
+                    f"'{key}' differs from the frame's."
+                )
+
+
+def _upload(datastore: Any, *, file: Path, name: str, doc_type: str, loa: str,
+            targets: List[str], description: str) -> str:
+    """Upload one store document; fail loud on any non-success (a withheld manifest is the
+    §3.2 torn-run protection — never swallow a shard failure and then commit)."""
+    result = datastore.upload_data(
+        file=file,
+        filename=name,
+        loa=loa,
+        name=name,
+        type=doc_type,
+        targets=targets,
+        category=FORECAST_CATEGORY,
+        description=description,
+    )
+    if not getattr(result, "success", False):
+        raise RuntimeError(
+            f"Prediction-store upload failed for '{name}' "
+            f"({getattr(result, 'error', 'no error detail')}). Aborting the publish leg — "
+            f"the manifest is withheld, so this (run, target) stays invisible to consumers "
+            f"(ADR-013 §3.2)."
+        )
+    return result.data["file_id"]
+
+
+def publish_sampled_forecast(
+    datastore: Any,
+    agg_pf: PredictionFrame,
+    *,
+    ensemble_name: str,
+    internal_target: str,
+    run_id: str,
+    level: str,
+    reconciled: bool,
+    generated_at: Optional[str] = None,
+    pipeline_core_version: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Publish one (run, target)'s pooled forecast as Track A archives + manifest (ADR-013 §3).
+
+    Args:
+        datastore: a `DatastoreModule`-shaped uploader (`upload_data(...) -> OperationResult`).
+        agg_pf: the aggregated (post-reconciliation, if configured) PredictionFrame — all
+            months of the horizon, pooled draws on axis 1.
+        ensemble_name: provenance (§2); NOT the wire identity.
+        internal_target: the internal target name; mapped via `wire_target` (§7a).
+        run_id: the run's wire identity — injectable (§10.2).
+        level: spatial level ("pgm").
+        reconciled: §2 provenance flag.
+        generated_at: injectable timestamp (§10.2); defaults to now-UTC (ISO, seconds).
+        pipeline_core_version: injectable for fixture byte-parity; defaults to self-report.
+
+    Returns:
+        The manifest dict that was uploaded (for logging/tests).
+    """
+    target = wire_target(internal_target)
+    if generated_at is None:
+        generated_at = datetime.now(timezone.utc).isoformat(timespec="seconds")
+
+    times = np.asarray(agg_pf.index.time, dtype=np.int64)
+    months = [int(t) for t in np.unique(times)]
+    shard_count = len(months)
+
+    # §3.2 expected_cell_count is a single value — ragged months would be a malformed run.
+    cells_per_month = {int(t): int((times == t).sum()) for t in months}
+    if len(set(cells_per_month.values())) != 1:
+        raise ValueError(
+            f"Malformed run: months carry differing cell counts {cells_per_month} — "
+            f"cannot publish a well-formed manifest (ADR-013 §3.2 expected_cell_count)."
+        )
+    expected_cell_count = next(iter(cells_per_month.values()))
+
+    shards: List[Dict[str, Any]] = []
+    with tempfile.TemporaryDirectory(prefix="track_a_publish_") as tmp:
+        tmp_path = Path(tmp)
+        for shard_index, time_id in enumerate(months):
+            month_pf = agg_pf.select(times == time_id)
+            stage_dir = tmp_path / f"stage_m{time_id:06d}"
+            save_pf(month_pf, stage_dir)  # §3.1: exactly what PFE already writes
+
+            header = build_header(
+                sample_count=agg_pf.sample_count,
+                spatial_level=level,
+                target_wire=target,
+                time_id=time_id,
+                run_id=run_id,
+                generated_at=generated_at,
+                ensemble_name=ensemble_name,
+                reconciled=reconciled,
+                shard_index=shard_index,
+                shard_count=shard_count,
+                pipeline_core_version=pipeline_core_version,
+            )
+            (stage_dir / "metadata.json").write_bytes(header_bytes(header))
+
+            _assert_staged_emission(stage_dir, month_pf, agg_pf.sample_count)
+
+            shard_name = SHARD_NAME_TEMPLATE.format(
+                run_id=run_id, target=target, time_id=time_id
+            )
+            zip_path = tmp_path / shard_name
+            with zipfile.ZipFile(zip_path, "w", compression=zipfile.ZIP_DEFLATED) as zf:
+                for member in ("y_pred.npy", "identifiers.npz", "metadata.json"):
+                    zf.write(stage_dir / member, arcname=member)
+
+            sha256 = hashlib.sha256(zip_path.read_bytes()).hexdigest()
+            file_id = _upload(
+                datastore,
+                file=zip_path,
+                name=shard_name,
+                doc_type=SHARD_TYPE,
+                loa=level,
+                targets=[target],
+                description=f"Track A sampled-forecast shard (ADR-013 §3.1), run {run_id}",
+            )
+            shards.append(
+                {"name": shard_name, "file_id": file_id, "sha256": sha256,
+                 "time_id": time_id}
+            )
+            logger.info(
+                "Published shard %s (S=%d, N=%d, sha256=%.12s…)",
+                shard_name, agg_pf.sample_count, month_pf.n_rows, sha256,
+            )
+
+        # §3.2 — the manifest, uploaded LAST: the commit marker for this (run, target).
+        manifest = {
+            "contract_version": WIRE_CONTRACT_VERSION,
+            "run_id": run_id,
+            "target": target,
+            "generated_at": generated_at,
+            "shards": shards,
+            "expected_months": months,
+            "expected_cell_count": expected_cell_count,
+            # §3.2 lists the §5 sidecar hash, but the sidecar is produced downstream
+            # (views-postprocessing) — the Hop-A producer has nothing to hash. Null by
+            # design; flagged to the contract author as a §3.2/§5.2 clarification.
+            "sidecar_sha256": None,
+        }
+        manifest_name = MANIFEST_NAME_TEMPLATE.format(run_id=run_id, target=target)
+        manifest_path = tmp_path / manifest_name
+        manifest_path.write_bytes((json.dumps(manifest, indent=2) + "\n").encode("utf-8"))
+        _upload(
+            datastore,
+            file=manifest_path,
+            name=manifest_name,
+            doc_type=MANIFEST_TYPE,
+            loa=level,
+            targets=[target],
+            description=f"Track A manifest (commit marker, ADR-013 §3.2), run {run_id}",
+        )
+        logger.info(
+            "Published manifest %s — %d shard(s) committed for (run=%s, target=%s).",
+            manifest_name, shard_count, run_id, target,
+        )
+    return manifest


### PR DESCRIPTION
Implements #269 per its amended acceptance criteria (post-adoption): the producer leg of the **Sampled-Forecast Wire Contract** (views-postprocessing **ADR-013**, Accepted 2026-07-15, v1.5). Precondition trail: contract adopted (§0.2 satisfied), Hop-A legacy transition guard merged (views-postprocessing #99) — so the §11.4 sequencing constraint is met for this store.

## What
- **`sampled_forecast_publisher.py`** (new, free-function module): per (run, target, month) — stage exactly what PFE writes (`save_pf`), add the §2 header (`metadata.json`), zip, upload; **manifest uploaded last** per (run, target) as the commit marker; any shard failure aborts before the manifest (no torn runs).
- **§3.4 emission assert** on the staged files pre-zip (S/dtype/N/identifier equality) — the producer vouches for its own emission; the FAO policy stays downstream at §6 (knowledge locality).
- **§3.3 naming constants** + golden-string tests; **§7a wire mapping** (`lr_ged_sb/ns/os`, fail-loud on unmapped); **§10.2 injectable `run_id`/`generated_at`** + a byte-pinned header test (fixture vendoring follows once the canonical fixture is published beside ADR-013).
- **PFE wiring**: gated on the existing `use_prediction_store` flag at `prediction_frame_ensemble.py:593`; lazy `DatastoreModule` via `PredictionStoreConfig.from_environment()` (model.py's exact pattern); **child runs keep never publishing** (`:731` untouched).

## Acceptance criteria (amended #269)
(a) §3.4 assert ✅ (b) golden-string names ✅ (c) injectable provenance + byte-pinned header ✅ (d) §2 header incl. §7a mapping ✅ (e) round-trip identity test ✅ (f) manifest-last + torn-run abort tests ✅ (g) gating unchanged ✅

## Notes
- `manifest.sidecar_sha256: null` — §3.2 lists the §5 sidecar hash, but the sidecar is a downstream artifact; flagged to the contract author as a §3.2/§5.2 clarification candidate.
- Local full-suite delta vs development: my domains green (560 passed in test_managers + falsification suites); the pre-existing editable-views-reporting drift failures in test_modules are unchanged (verified by stash-baseline; one apparent extra failure, `test_evaluation_adapter_golden`, is ordering pollution from that zone — passes standalone with this diff).

Closes #269.

🤖 Generated with [Claude Code](https://claude.com/claude-code)