### PR TITLE
feat(ensemble): fail loud on stale/wrong constituent sample count (C-85, sprint S1)

### DIFF
--- a/tests/test_ensemble_sample_count_guard.py
+++ b/tests/test_ensemble_sample_count_guard.py
@@ -1,0 +1,83 @@
+"""S1 (sprint: kill silent sample-count failures) — the fail-loud guard.
+
+The #160 balance guard (`_aggregate_prediction_frames`) rejects constituents
+whose sample counts DIFFER from each other. It cannot catch the case that cost
+the 2026-07-20 FAO delivery ~4 hours: every constituent reloaded a *stale*
+cached forecast at the SAME wrong count (all-equal-but-wrong), so the config's
+sample-count change was silently discarded with no error, log, or test.
+
+`_assert_expected_sample_count` closes that gap: it compares each constituent's
+PRODUCED `pf.sample_count` against the ensemble config's declared
+`expected_samples_per_model` and fails loud on mismatch, while returning the
+produced counts for forecast-time logging. Register C-85.
+"""
+import numpy as np
+import pytest
+from views_frames import PredictionFrame, SpatialLevel, SpatioTemporalIndex
+
+from views_pipeline_core.managers.ensemble.prediction_frame_ensemble import (
+    _assert_expected_sample_count,
+)
+
+
+def _pf(n_rows, n_samples, seed=0):
+    rng = np.random.default_rng(seed)
+    idx = SpatioTemporalIndex(
+        np.repeat(np.int64(500), n_rows),
+        np.arange(n_rows, dtype=np.int64),
+        SpatialLevel.PGM,
+    )
+    return PredictionFrame(
+        rng.uniform(0, 5, size=(n_rows, n_samples)).astype(np.float32), idx
+    )
+
+
+def _results(models, sample_count, targets=("lr_sb_best",)):
+    """A model_results dict: {model: {target: PF}} all at `sample_count`."""
+    return {
+        m: {t: _pf(6, sample_count, seed=i) for t in targets}
+        for i, m in enumerate(models)
+    }
+
+
+MODELS = ["a", "b", "c"]
+TARGETS = ["lr_sb_best"]
+
+
+def test_returns_produced_counts_when_all_match():
+    results = _results(MODELS, 16)
+    produced = _assert_expected_sample_count(results, 16, MODELS, TARGETS)
+    assert produced == {"a": 16, "b": 16, "c": 16}
+
+
+def test_raises_when_all_equal_but_wrong():
+    # tonight's exact bug: config expects 16, stale cache served 128 everywhere.
+    # #160 sees them equal and passes; this guard must fail loud.
+    results = _results(MODELS, 128)
+    with pytest.raises(ValueError, match="expects 16"):
+        _assert_expected_sample_count(results, 16, MODELS, TARGETS)
+
+
+def test_error_names_the_constituent_and_the_remedy():
+    results = _results(MODELS, 128)
+    with pytest.raises(ValueError) as exc:
+        _assert_expected_sample_count(results, 16, MODELS, TARGETS)
+    msg = str(exc.value)
+    assert "'a'" in msg and "128" in msg
+    assert "predictions_" in msg  # points at the stale-cache remedy
+
+
+def test_no_expectation_declared_skips_enforcement_but_still_reports():
+    # An ensemble that declares no expected_samples_per_model must not crash;
+    # the produced counts are still returned for logging.
+    results = _results(MODELS, 64)
+    produced = _assert_expected_sample_count(results, None, MODELS, TARGETS)
+    assert produced == {"a": 64, "b": 64, "c": 64}
+
+
+def test_catches_a_single_divergent_constituent():
+    # mixed on disk (some regenerated, some stale) — must fire on the wrong one.
+    results = _results(["a", "b"], 16)
+    results["c"] = {"lr_sb_best": _pf(6, 128, seed=9)}
+    with pytest.raises(ValueError, match="'c'.*128|128.*expects 16"):
+        _assert_expected_sample_count(results, 16, MODELS, TARGETS)

--- a/views_pipeline_core/managers/ensemble/dataframe_ensemble.py
+++ b/views_pipeline_core/managers/ensemble/dataframe_ensemble.py
@@ -72,6 +72,7 @@ class EnsembleContext(BaseStageContext):
     deployment_status: str
     prediction_format: str
     partition_dict: Dict[str, Any]
+    expected_samples_per_model: Optional[int] = None
 
 
 # ---------------------------------------------------------------------------

--- a/views_pipeline_core/managers/ensemble/prediction_frame_ensemble.py
+++ b/views_pipeline_core/managers/ensemble/prediction_frame_ensemble.py
@@ -124,6 +124,49 @@ def _aggregate_prediction_frames(
     return PredictionFrame(y_agg, reference.index)
 
 
+def _assert_expected_sample_count(
+    model_results: Dict[str, Dict[str, PredictionFrame]],
+    expected_samples_per_model: Optional[int],
+    models: List[str],
+    targets: List[str],
+) -> Dict[str, int]:
+    """Fail loud when a constituent's PRODUCED sample count is not what the config
+    expects, and return the produced counts for logging.
+
+    The #160 balance guard (`_aggregate_prediction_frames`) rejects constituents
+    whose sample counts differ FROM EACH OTHER. It cannot see the case where every
+    constituent reloaded a stale cached forecast at the same wrong count
+    (all-equal-but-wrong) — the failure that silently discarded a sample-count
+    config change during the 2026-07-20 FAO delivery (register C-85). This compares
+    the produced `pf.sample_count` against the ensemble config's declared
+    `expected_samples_per_model`; when that is undeclared the check is a no-op and
+    only reports the produced counts.
+    """
+    produced: Dict[str, int] = {}
+    for model_name in models:
+        target_pfs = model_results.get(model_name, {})
+        pf = next(
+            (target_pfs[t] for t in targets if target_pfs.get(t) is not None), None
+        )
+        if pf is None:
+            continue
+        produced[model_name] = pf.sample_count
+        if (
+            expected_samples_per_model is not None
+            and pf.sample_count != expected_samples_per_model
+        ):
+            raise ValueError(
+                f"Constituent '{model_name}' produced {pf.sample_count} samples but "
+                f"the ensemble config expects {expected_samples_per_model} "
+                f"(expected_samples_per_model). A stale or mismatched cached forecast "
+                f"is being reused: clear models/{model_name}/data/generated/"
+                f"predictions_* and re-run, or fix the constituent's sample-count "
+                f"config. (This is the all-equal-but-wrong case the #160 balance "
+                f"guard cannot detect — register C-85.)"
+            )
+    return produced
+
+
 # ---------------------------------------------------------------------------
 # PredictionFrameEnsembleManager
 # ---------------------------------------------------------------------------
@@ -316,6 +359,7 @@ class PredictionFrameEnsembleManager:
             deployment_status=c.get("deployment_status", "shadow"),
             prediction_format="prediction_frame",
             partition_dict=self._partition_dict or {},
+            expected_samples_per_model=c.get("expected_samples_per_model"),
         )
 
     # ------------------------------------------------------------------
@@ -568,6 +612,24 @@ class PredictionFrameEnsembleManager:
             model_results[model_name] = self._forecast_model_artifact(
                 model_name, ctx
             )
+
+        # Fail loud if a constituent's PRODUCED sample count is not what the config
+        # expects, and record the produced counts (register C-85): the only visible
+        # signal that a stale cached forecast was reloaded used to be progress-bar
+        # duration. The #160 balance guard cannot catch all-equal-but-wrong.
+        produced_counts = _assert_expected_sample_count(
+            model_results,
+            ctx.expected_samples_per_model,
+            ctx.models,
+            ctx.targets,
+        )
+        logger.info(
+            "Ensemble '%s' forecast sample counts per constituent: %s "
+            "(expected_samples_per_model=%s)",
+            ctx.configs["name"],
+            produced_counts,
+            ctx.expected_samples_per_model,
+        )
 
         forecasts: Dict[str, PredictionFrame] = {}
         for target in ctx.targets:


### PR DESCRIPTION
Closes the all-equal-but-wrong gap the #160 balance guard can't see: every constituent reloading a stale cached forecast at the same wrong sample count silently discards a config change (the 2026-07-20 FAO delivery burned ~4h on it). `_assert_expected_sample_count` fails loud against the ensemble config's `expected_samples_per_model` and logs the produced counts at forecast time. Additive + backward-compatible (no-op without the config key). 5 new tests, all existing PF-ensemble/#160 tests green, ruff clean.

Sprint S1 / register C-85. Follow-up S2 makes the cache itself config-aware.

🤖 Generated with [Claude Code](https://claude.com/claude-code)