### PR TITLE
feat(ensemble): config-aware forecast cache — regenerate stale sample counts (C-85, sprint S2)

### DIFF
--- a/tests/test_ensemble_cache_staleness.py
+++ b/tests/test_ensemble_cache_staleness.py
@@ -1,0 +1,119 @@
+"""S2 (sprint: kill silent sample-count failures) — config-aware forecast cache.
+
+The ensemble cached each constituent forecast as y_pred.npy in a directory keyed
+on the sample-agnostic MODEL ARTIFACT timestamp; editing the sample count never
+changed the artifact, so `_load_or_generate_pf` reloaded the stale forecast at
+the old count and the config change vanished (register C-85, the 2026-07-20 FAO
+delivery). S1 made that fail loud AFTER the fact; S2 makes the cache
+config-aware so it REGENERATES instead of reusing.
+
+The check reads the cached array's ACTUAL sample width (which cannot lie about
+itself) rather than a self-reported sidecar, and compares it to the ensemble's
+expected_samples_per_model.
+"""
+import numpy as np
+from unittest.mock import MagicMock
+from views_frames import PredictionFrame, SpatialLevel, SpatioTemporalIndex
+
+from views_pipeline_core.managers.ensemble.prediction_frame_ensemble import (
+    PredictionFrameEnsembleManager,
+    _cached_sample_count,
+)
+from views_pipeline_core.managers.prediction.prediction_frame_io import save_pf
+
+
+def _write_pf(pf_dir, n_rows, n_samples, seed=0):
+    pf_dir.mkdir(parents=True, exist_ok=True)
+    rng = np.random.default_rng(seed)
+    idx = SpatioTemporalIndex(
+        np.arange(n_rows, dtype=np.int64),
+        np.arange(1000, 1000 + n_rows, dtype=np.int64),
+        SpatialLevel.PGM,
+    )
+    save_pf(
+        PredictionFrame(rng.uniform(0, 5, (n_rows, n_samples)).astype(np.float32), idx),
+        pf_dir,
+    )
+
+
+# --- the peek helper (reads reality, no sidecar) --------------------------
+
+def test_cached_sample_count_reads_actual_width(tmp_path):
+    _write_pf(tmp_path / "d", 8, 16)
+    assert _cached_sample_count(tmp_path / "d") == 16
+
+
+def test_cached_sample_count_none_when_absent(tmp_path):
+    assert _cached_sample_count(tmp_path / "missing") is None
+
+
+def test_cached_sample_count_none_for_nonstandard_array(tmp_path):
+    d = tmp_path / "d"
+    d.mkdir()
+    np.save(d / "y_pred.npy", np.arange(5))  # 1-D, not (N, S)
+    assert _cached_sample_count(d) is None
+
+
+# --- the config-aware load: regenerate on mismatch ------------------------
+
+def _bare_manager():
+    mgr = object.__new__(PredictionFrameEnsembleManager)
+    mgr._wandb_module = MagicMock()
+    mgr._create_model_args = MagicMock(return_value=MagicMock())
+    return mgr
+
+
+def _ctx(expected):
+    ctx = MagicMock()
+    ctx.configs = {"level": "pgm"}
+    ctx.expected_samples_per_model = expected
+    return ctx
+
+
+def test_reuses_cache_when_width_matches_expected(tmp_path):
+    pf_dir = tmp_path / "predictions_forecasting_x" / "lr_sb_best"
+    _write_pf(pf_dir, 8, 16)
+    mgr = _bare_manager()
+    mgr._execute_shell_script = MagicMock()  # must NOT be called
+
+    out = mgr._load_or_generate_pf(
+        model_path=MagicMock(), model_name="m", pf_dir=pf_dir,
+        ctx=_ctx(16), forecast=True,
+    )
+    assert out.sample_count == 16
+    mgr._execute_shell_script.assert_not_called()
+
+
+def test_regenerates_when_cached_width_is_stale(tmp_path):
+    # tonight's bug: cache is S=128, config now expects 16 → must regenerate.
+    pf_dir = tmp_path / "predictions_forecasting_x" / "lr_sb_best"
+    _write_pf(pf_dir, 8, 128)
+
+    mgr = _bare_manager()
+
+    def fake_shell(model_path, model_name, model_args):
+        _write_pf(pf_dir, 8, 16)  # the constituent regenerates fresh at 16
+
+    mgr._execute_shell_script = MagicMock(side_effect=fake_shell)
+
+    out = mgr._load_or_generate_pf(
+        model_path=MagicMock(), model_name="m", pf_dir=pf_dir,
+        ctx=_ctx(16), forecast=True,
+    )
+    mgr._execute_shell_script.assert_called_once()  # did NOT blindly reuse
+    assert out.sample_count == 16  # returns the fresh frame
+
+
+def test_reuses_cache_when_no_expectation_declared(tmp_path):
+    # ensembles without expected_samples_per_model keep the old load behaviour.
+    pf_dir = tmp_path / "predictions_forecasting_x" / "lr_sb_best"
+    _write_pf(pf_dir, 8, 64)
+    mgr = _bare_manager()
+    mgr._execute_shell_script = MagicMock()
+
+    out = mgr._load_or_generate_pf(
+        model_path=MagicMock(), model_name="m", pf_dir=pf_dir,
+        ctx=_ctx(None), forecast=True,
+    )
+    assert out.sample_count == 64
+    mgr._execute_shell_script.assert_not_called()

--- a/views_pipeline_core/managers/ensemble/prediction_frame_ensemble.py
+++ b/views_pipeline_core/managers/ensemble/prediction_frame_ensemble.py
@@ -167,6 +167,26 @@ def _assert_expected_sample_count(
     return produced
 
 
+def _cached_sample_count(pf_dir: Path) -> Optional[int]:
+    """The sample width (axis 1) of a cached ``y_pred.npy`` without loading it,
+    or None if the file is absent or not a 2-D (N, S) array.
+
+    Reads the array's own shape header via mmap — cheap, and it reports what the
+    cache ACTUALLY contains rather than a self-reported metadata value that could
+    itself drift. Used to detect a sample-count-stale cache (register C-85).
+    """
+    y_pred_path = Path(pf_dir) / "y_pred.npy"
+    if not y_pred_path.exists():
+        return None
+    try:
+        arr = np.load(y_pred_path, mmap_mode="r")
+    except Exception:  # noqa: BLE001 — an unreadable peek must never break the
+        # load path; returning None defers to load_pf (and S1 still guards the
+        # produced count downstream).
+        return None
+    return int(arr.shape[1]) if arr.ndim == 2 else None
+
+
 # ---------------------------------------------------------------------------
 # PredictionFrameEnsembleManager
 # ---------------------------------------------------------------------------
@@ -875,15 +895,31 @@ class PredictionFrameEnsembleManager:
     ) -> PredictionFrame:
         y_pred_path = pf_dir / "y_pred.npy"
         if y_pred_path.exists():
+            # Config-aware cache (register C-85): the cache dir is keyed on the
+            # sample-agnostic model-artifact timestamp, so a sample-count config
+            # change leaves the stale y_pred.npy in place and it would be reused
+            # silently. Peek the cached array's ACTUAL sample width (it cannot lie
+            # about itself) and regenerate when it no longer matches the ensemble's
+            # expected count, instead of blindly reloading.
+            cached = _cached_sample_count(pf_dir)
+            expected = ctx.expected_samples_per_model
+            if expected is not None and cached is not None and cached != expected:
+                logger.warning(
+                    "Stale cached forecast at %s: cached sample_count=%s but the "
+                    "ensemble config expects %s — regenerating instead of reusing "
+                    "(register C-85).",
+                    pf_dir,
+                    cached,
+                    expected,
+                )
+            else:
+                logger.info(f"Loading existing PredictionFrame from {pf_dir}")
+                return load_pf(pf_dir, ctx.configs["level"], mmap=mmap)
+        else:
             logger.info(
-                f"Loading existing PredictionFrame from {pf_dir}"
+                f"No existing PredictionFrame at {pf_dir}. "
+                f"Generating new predictions..."
             )
-            return load_pf(pf_dir, ctx.configs["level"], mmap=mmap)
-
-        logger.info(
-            f"No existing PredictionFrame at {pf_dir}. "
-            f"Generating new predictions..."
-        )
         model_args = self._create_model_args(
             ctx, evaluate=evaluate, forecast=forecast
         )


### PR DESCRIPTION
Structural close of C-85: the constituent cache is keyed on the sample-agnostic artifact timestamp, so a sample-count change left the stale y_pred.npy reused silently. `_cached_sample_count` peeks the cached array's real width (reads reality, no drifting sidecar) and `_load_or_generate_pf` regenerates on mismatch vs `expected_samples_per_model`. Defensive (unreadable peek → defer to load; S1 still guards), no-op without the config key. 7 new tests + 3 restored loading tests + regressions green, ruff clean. Sprint S2 (follows S1 #281).

🤖 Generated with [Claude Code](https://claude.com/claude-code)