### PR TITLE
feat(adapter): from_actual_arrays — frame-native actuals entry, zero behavior change (#301, epic #300)

### DIFF
--- a/tests/test_modules/test_evaluation_adapter_arrays.py
+++ b/tests/test_modules/test_evaluation_adapter_arrays.py
@@ -1,0 +1,173 @@
+"""#301 (epic #300) — EvaluationAdapter.from_actual_arrays: the frame-native entry.
+
+Contract: byte-identical EvaluationFrames through the pandas entry and the
+numpy-triple entry, with the same guards.
+"""
+from types import SimpleNamespace
+
+import numpy as np
+import pandas as pd
+import pytest
+from views_frames import PredictionFrame, SpatialLevel, SpatioTemporalIndex
+
+from views_pipeline_core.modules.validation.adapter import EvaluationAdapter
+
+
+def _pf(times, n_units=3, n_samples=4, seed=0):
+    rng = np.random.default_rng(seed)
+    time = np.repeat(np.asarray(times, dtype=np.int64), n_units)
+    unit = np.tile(np.arange(1, n_units + 1, dtype=np.int64), len(times))
+    return PredictionFrame(
+        rng.uniform(0, 5, size=(len(time), n_samples)).astype(np.float32),
+        SpatioTemporalIndex(time, unit, SpatialLevel.PGM),
+    )
+
+
+def _actuals(times=range(500, 506), n_units=3, seed=1):
+    rng = np.random.default_rng(seed)
+    time = np.repeat(np.asarray(list(times), dtype=np.int64), n_units)
+    unit = np.tile(np.arange(1, n_units + 1, dtype=np.int64), len(list(times)))
+    values = rng.uniform(0, 9, size=len(time))
+    df = pd.DataFrame(
+        {"lr_sb_best": values},
+        index=pd.MultiIndex.from_arrays([time, unit], names=["month_id", "priogrid_id"]),
+    )
+    return df, (time, unit, values)
+
+
+PREDICTIONS = [_pf([501, 502], seed=2), _pf([502, 503], seed=3)]
+STEP_MAPPING = [{501: 1, 502: 2}, {502: 1, 503: 2}]
+
+
+def _assert_ef_equal(a, b):
+    np.testing.assert_array_equal(a.y_true, b.y_true)
+    assert a.y_true.dtype == b.y_true.dtype
+    np.testing.assert_array_equal(a.y_pred, b.y_pred)
+    assert a.y_pred.dtype == b.y_pred.dtype
+    for key in ("time", "unit", "origin", "step"):
+        np.testing.assert_array_equal(a.identifiers[key], b.identifiers[key])
+    assert a.metadata == b.metadata
+
+
+# ------------------------------------------------------------------ equivalence
+
+
+def test_both_entries_are_byte_identical():
+    df, (t, u, v) = _actuals()
+    ef_df = EvaluationAdapter.from_prediction_frames(
+        df, PREDICTIONS, "lr_sb_best", STEP_MAPPING
+    )
+    ef_np = EvaluationAdapter.from_actual_arrays(
+        t, u, v, PREDICTIONS, "lr_sb_best", STEP_MAPPING
+    )
+    _assert_ef_equal(ef_df, ef_np)
+
+
+def test_equivalence_without_step_mapping():
+    df, (t, u, v) = _actuals()
+    ef_df = EvaluationAdapter.from_prediction_frames(df, PREDICTIONS, "lr_sb_best")
+    ef_np = EvaluationAdapter.from_actual_arrays(t, u, v, PREDICTIONS, "lr_sb_best")
+    _assert_ef_equal(ef_df, ef_np)
+
+
+# ------------------------------------------------------------------ guards
+
+
+def test_misaligned_arrays_fail_loud():
+    _, (t, u, v) = _actuals()
+    with pytest.raises(ValueError, match="aligned"):
+        EvaluationAdapter.from_actual_arrays(t[:-1], u, v, PREDICTIONS, "x")
+
+
+def test_non_1d_arrays_fail_loud():
+    _, (t, u, v) = _actuals()
+    with pytest.raises(ValueError, match="1-D"):
+        EvaluationAdapter.from_actual_arrays(
+            t.reshape(-1, 1), u.reshape(-1, 1), v.reshape(-1, 1), PREDICTIONS, "x"
+        )
+
+
+def test_empty_actuals_fail_loud():
+    with pytest.raises(ValueError, match="empty"):
+        EvaluationAdapter.from_actual_arrays(
+            np.array([], dtype=np.int64), np.array([], dtype=np.int64),
+            np.array([]), PREDICTIONS, "x",
+        )
+
+
+def test_empty_predictions_fail_loud():
+    _, (t, u, v) = _actuals()
+    with pytest.raises(ValueError, match="concatenate"):
+        EvaluationAdapter.from_actual_arrays(t, u, v, [], "x")
+
+
+def test_mapping_count_guard():
+    _, (t, u, v) = _actuals()
+    with pytest.raises(ValueError, match="step_mapping list length"):
+        EvaluationAdapter.from_actual_arrays(
+            t, u, v, PREDICTIONS, "x", [STEP_MAPPING[0]]
+        )
+
+
+def test_rogue_month_guard():
+    _, (t, u, v) = _actuals()
+    with pytest.raises(ValueError, match="not in the declared step_mapping"):
+        EvaluationAdapter.from_actual_arrays(
+            t, u, v, PREDICTIONS, "x", [{501: 1}, {502: 1, 503: 2}]
+        )
+
+
+def test_nan_identifier_guard():
+    _, (t, u, v) = _actuals()
+    bad = SimpleNamespace(
+        identifiers={
+            "time": np.array([501.0, np.nan]),
+            "unit": np.array([1.0, 2.0]),
+        },
+        values=np.ones((2, 4), dtype=np.float32),
+    )
+    with pytest.raises(ValueError, match="NaN detected in 'time'"):
+        EvaluationAdapter.from_actual_arrays(t, u, v, [bad], "x")
+
+
+def test_nat_identifier_guard():
+    """Temporal NaT must be caught (the pd.isna parity case the review found)."""
+    _, (t, u, v) = _actuals()
+    bad = SimpleNamespace(
+        identifiers={
+            "time": np.array(["2020-01", "NaT"], dtype="datetime64[M]"),
+            "unit": np.array([1, 2], dtype=np.int64),
+        },
+        values=np.ones((2, 4), dtype=np.float32),
+    )
+    with pytest.raises(ValueError, match="NaN detected in 'time'"):
+        EvaluationAdapter.from_actual_arrays(t, u, v, [bad], "x")
+
+
+def test_non_integer_float_ids_fail_loud():
+    _, (t, u, v) = _actuals()
+    with pytest.raises(ValueError, match="non-integer"):
+        EvaluationAdapter.from_actual_arrays(
+            t.astype(np.float64) + 0.5, u, v, PREDICTIONS, "x"
+        )
+
+
+def test_integer_valued_float_ids_accepted():
+    _, (t, u, v) = _actuals()
+    ef = EvaluationAdapter.from_actual_arrays(
+        t.astype(np.float64), u.astype(np.float64), v, PREDICTIONS,
+        "lr_sb_best", STEP_MAPPING,
+    )
+    df, _ = _actuals()
+    _assert_ef_equal(
+        EvaluationAdapter.from_prediction_frames(df, PREDICTIONS, "lr_sb_best", STEP_MAPPING),
+        ef,
+    )
+
+
+def test_object_dtype_actuals_rejected():
+    _, (t, u, v) = _actuals()
+    with pytest.raises(ValueError, match="Object-dtype"):
+        EvaluationAdapter.from_actual_arrays(
+            t, u, v.astype(object), PREDICTIONS, "x"
+        )

--- a/views_pipeline_core/modules/validation/adapter.py
+++ b/views_pipeline_core/modules/validation/adapter.py
@@ -6,6 +6,24 @@ from views_evaluation.evaluation.evaluation_frame import EvaluationFrame
 
 logger = logging.getLogger(__name__)
 
+
+def _identifier_has_nan(values) -> bool:
+    """NaN check for identifier arrays without pandas (#301).
+
+    Integer arrays cannot hold NaN; float-castable arrays are checked with
+    np.isnan; anything non-numeric is treated as invalid (as bad as NaN —
+    the subsequent int64 cast could only produce garbage).
+    """
+    arr = np.asarray(values)
+    if arr.dtype.kind in ("i", "u"):
+        return False
+    if arr.dtype.kind in ("M", "m"):  # datetime64/timedelta64: NaT ≠ nan after cast
+        return bool(np.any(np.isnat(arr)))
+    try:
+        return bool(np.any(np.isnan(arr.astype(np.float64))))
+    except (TypeError, ValueError):
+        return True
+
 class EvaluationAdapter:
     """
     Adapter to convert Pandas DataFrames into the native EvaluationFrame.
@@ -298,6 +316,10 @@ class EvaluationAdapter:
         EvaluationFrame. Mirrors from_dataframes() exactly but uses the dense
         PredictionFrame arrays directly, bypassing list-in-cell explosion.
 
+        The pandas entry point: reduces the actuals DataFrame to numpy arrays and
+        delegates to the shared numpy core (also exposed as from_actual_arrays for
+        the frame-native path, #301).
+
         Args:
             actual: DataFrame with MultiIndex [time, unit]
             predictions: List of PredictionFrames, one per rolling-origin sequence.
@@ -310,6 +332,82 @@ class EvaluationAdapter:
         if target not in actual.columns:
             raise KeyError(f"Target column '{target}' not found in actuals.")
 
+        # ── Reduce pandas to numpy once; everything downstream is pandas-free ──
+        act_time = actual.index.get_level_values(0).values.astype(np.int64)
+        act_unit = actual.index.get_level_values(1).values.astype(np.int64)
+        act_y_true_vals = actual[target].values
+
+        # Coerce object-dtype actuals once (legacy list-in-cell support — pandas-side only)
+        if act_y_true_vals.dtype == object:
+            act_y_true_vals = np.array([
+                x[0] if isinstance(x, (list, np.ndarray)) and len(x) > 0 else x
+                for x in act_y_true_vals
+            ], dtype=np.float64)
+
+        return EvaluationAdapter._from_actual_arrays(
+            act_time, act_unit, act_y_true_vals, predictions, target, step_mapping
+        )
+
+    @staticmethod
+    def from_actual_arrays(
+        act_time: np.ndarray,
+        act_unit: np.ndarray,
+        act_values: np.ndarray,
+        predictions: List[Any],  # List[PredictionFrame]
+        target: str,
+        step_mapping: Optional[List[Dict[int, int]]] = None,
+    ) -> EvaluationFrame:
+        """
+        Frame-native entry (#301, epic #300): identical semantics and guards as
+        from_prediction_frames, taking the actuals as three aligned numpy arrays
+        (time ids, unit ids, values) instead of a pandas DataFrame — the exact
+        representation the pandas entry reduces to internally.
+
+        ``target`` is metadata only here (stamped on the EvaluationFrame); the
+        caller has already selected the target's values.
+        """
+        act_time_raw = np.asarray(act_time)
+        act_unit_raw = np.asarray(act_unit)
+        for name, raw in (("time", act_time_raw), ("unit", act_unit_raw)):
+            if raw.dtype.kind == "f" and not np.all(raw == np.floor(raw)):
+                raise ValueError(
+                    f"Actual '{name}' ids contain non-integer values — an int64 "
+                    f"cast would silently truncate them."
+                )
+        act_time = act_time_raw.astype(np.int64)
+        act_unit = act_unit_raw.astype(np.int64)
+        act_values = np.asarray(act_values)
+        if act_values.dtype == object:
+            raise ValueError(
+                "Object-dtype actuals are not supported by the array entry — "
+                "coerce to a numeric array first (the pandas entry's legacy "
+                "list-in-cell coercion is deliberately pandas-side only)."
+            )
+        if not (act_time.ndim == act_unit.ndim == act_values.ndim == 1):
+            raise ValueError(
+                "Actuals arrays must be 1-D (time ids, unit ids, values)."
+            )
+        if not (len(act_time) == len(act_unit) == len(act_values)):
+            raise ValueError(
+                f"Actuals arrays must be aligned: len(time)={len(act_time)}, "
+                f"len(unit)={len(act_unit)}, len(values)={len(act_values)}."
+            )
+        if len(act_time) == 0:
+            raise ValueError("Actuals arrays are empty — nothing to evaluate against.")
+        return EvaluationAdapter._from_actual_arrays(
+            act_time, act_unit, act_values, predictions, target, step_mapping
+        )
+
+    @staticmethod
+    def _from_actual_arrays(
+        act_time: np.ndarray,
+        act_unit: np.ndarray,
+        act_y_true_vals: np.ndarray,
+        predictions: List[Any],
+        target: str,
+        step_mapping: Optional[List[Dict[int, int]]],
+    ) -> EvaluationFrame:
+        """Shared numpy core for both entries. All guards live here."""
         if not predictions:
             raise ValueError("No objects to concatenate")
 
@@ -320,18 +418,6 @@ class EvaluationAdapter:
                 f"of prediction sequences ({len(predictions)}). Each sequence requires "
                 f"its own explicit origin-anchored mapping."
             )
-
-        # ── Pre-compute actual-index lookup (once, numpy — no pandas objects in loop) ──
-        act_time = actual.index.get_level_values(0).values.astype(np.int64)
-        act_unit = actual.index.get_level_values(1).values.astype(np.int64)
-        act_y_true_vals = actual[target].values
-
-        # Coerce object-dtype actuals once (legacy list-in-cell support)
-        if act_y_true_vals.dtype == object:
-            act_y_true_vals = np.array([
-                x[0] if isinstance(x, (list, np.ndarray)) and len(x) > 0 else x
-                for x in act_y_true_vals
-            ], dtype=np.float64)
 
         # Compound key: time × scale + unit  (unique as long as unit_id < scale)
         _scale = int(act_unit.max()) + 1
@@ -363,12 +449,13 @@ class EvaluationAdapter:
                         f"model's actual forecast origin for this sequence."
                     )
 
-            # NaN check before int64 cast (NaN silently becomes a garbage int64 value)
+            # NaN check before int64 cast (NaN silently becomes a garbage int64 value).
+            # numpy-based (#301): the shared core must not require pandas.
             pf_time_raw = pf.identifiers['time']
             pf_unit_raw = pf.identifiers['unit']
-            if np.any(pd.isna(pf_time_raw)):
+            if _identifier_has_nan(pf_time_raw):
                 raise ValueError(f"NaN detected in 'time' identifiers of sequence {i}.")
-            if np.any(pd.isna(pf_unit_raw)):
+            if _identifier_has_nan(pf_unit_raw):
                 raise ValueError(f"NaN detected in 'unit' identifiers of sequence {i}.")
 
             pf_time = pf_time_raw.astype(np.int64)


### PR DESCRIPTION
**Epic #300, S1** (tracking #303). The pandas entry reduces-then-delegates; the numpy entry is byte-identical (pinned) with the shared guards plus its own (aligned/1-D/non-empty, non-integer-float ids loud, object dtype rejected). Review caught a real parity hole in the pd.isna→numpy swap — datetime64 **NaT** would have cast to garbage int64 silently; fixed + regression test.

Verification: 40/40 across all three adapter suites (incl. goldens); full suite **1464 passed**; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)