### PR TITLE
chore: datafactory install hint → PyPI floor pin

### DIFF
--- a/views_pipeline_core/modules/dataloaders/datafactory_contract.py
+++ b/views_pipeline_core/modules/dataloaders/datafactory_contract.py
@@ -70,8 +70,7 @@ def import_datafactory_contract(model_name: str) -> DatafactoryContract:
             f"datafactory_query with the ADR-050 consumer-contract exports "
             f"(views-datafactory >= 1.8.0) is required for model {model_name} "
             f"(source='views-datafactory') but is not installed or too old. "
-            f"Install/upgrade via: pip install 'views-datafactory @ "
-            f"git+https://github.com/views-platform/views-datafactory.git@development'"
+            f'Install/upgrade via: pip install "views-datafactory>=1.9.0"'
         ) from e
     return DatafactoryContract(
         load_dataset, OutputFormat, is_valid_output_format, CONTRACT_VERSION


### PR DESCRIPTION
views-datafactory is on PyPI as of v1.9.0 (`pip install views-datafactory`). The ImportError hint in datafactory_contract.py now recommends the release floor pin instead of the `@development` branch — which could never enforce the >=1.8.0 contract floor the message states.

Part of the cross-repo tagged-release rollout after views-datafactory went public.

🤖 Generated with [Claude Code](https://claude.com/claude-code)