### PR TITLE
docs(register): point the 3.0.0 release gate at live issues, not prose

### DIFF
--- a/reports/technical_risk_register.md
+++ b/reports/technical_risk_register.md
@@ -8,8 +8,8 @@
 > pinned consumer repos. These entries must be closed or *consciously accepted* before tagging:
 > ~~**C-227**, **C-228**, **C-231**~~ — **CLOSED 2026-07-31** (#329/#330/#331); the remaining
 > Appwrite-seam gate item is running `reconcile.py` against production (C-236), **C-193 residual** (nothing enforces that a breaking public-symbol change
-> forces a major bump — and this release *is* that event), **C-190 residual** (no declared
-> `views-reporting` floor in `pyproject.toml`), **C-206** (every proof that would validate the
+> forces a major bump — and this release *is* that event) → **#374**, **C-190 residual** (no declared
+> `views-reporting` floor in `pyproject.toml`) → **#375**, **C-206** → **#274** (every proof that would validate the
 > release runs against editable worktrees, and this box holds `views-frames 1.8.0` while the train
 > assumes 1.10.0), plus the known `views-evaluation ^0.4.0 → ^0.5.0` bump awaiting the leaf release.
 


### PR DESCRIPTION
Two release-gate items existed only as a sentence inside #313's body, so nothing would surface them at tagging time.

| Gate item | Register | Now tracked |
|---|---|---|
| Nothing enforces that a breaking public-symbol change forces a major bump — **and 3.0.0 is that event** | C-193 (T2) | **#374** |
| No declared `views-reporting` floor in `pyproject.toml` | C-190 (T2) | **#375** |
| Proofs run against editable worktrees | C-206 (T2) | #274 *(existed)* |

The gate's own wording is *"closed or **consciously accepted** before tagging"*. Neither is possible while an item is prose nobody re-reads.

Both new issues state the alternative explicitly — what conscious acceptance would look like — because for at least one of them that may be the right answer. #375 in particular may resolve as *"no floor can be stated until views-reporting cuts a release"*, which is better than a guessed pin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)