### PR TITLE
chore(deps): require views-frames >=1.10.2 — raise the floor, keep the ceiling

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ views-evaluation = "^0.5.0"
 views-transformation-library = "^2.7.2"
 art = "^6.4"
 polars = ">=1.34.0,<2.0.0"
-views-frames = "^1.8"
+views-frames = "^1.10.2"
 
 # OPTIONAL (#345, register C-253). Appwrite is the SECONDARY EXTERNAL destination under
 # ADR-047 — local disk is authoritative and views-forecasts is the primary external

--- a/reports/technical_risk_register.md
+++ b/reports/technical_risk_register.md
@@ -9,9 +9,7 @@
 > ~~**C-227**, **C-228**, **C-231**~~ — **CLOSED 2026-07-31** (#329/#330/#331); the remaining
 > Appwrite-seam gate item is running `reconcile.py` against production (C-236), **C-193 residual** (nothing enforces that a breaking public-symbol change
 > forces a major bump — and this release *is* that event) → **#374**, **C-190 residual** (no declared
-> `views-reporting` floor in `pyproject.toml`) → **#375**, **C-206** → **#274** (every proof that would validate the
-> release runs against editable worktrees, and this box holds `views-frames 1.8.0` while the train
-> assumes 1.10.0), ~~plus the known `views-evaluation ^0.4.0 → ^0.5.0` bump awaiting the leaf release~~ — **DONE 2026-08-02**: views-evaluation 0.5.0 published to PyPI, pin bumped, and the adoption verified against the **published wheel** in a clean venv rather than the editable checkout: `to_metric_frame` present, all six kwargs `evaluation/stage.py` passes accepted, and a real 12-key combined config **accepted** by their new fail-loud validator.
+> `views-reporting` floor in `pyproject.toml`) → **#375**, **C-206** (every proof that would validate the release runs against editable worktrees — **the views-frames half is now CLOSED (2026-08-02): the box has been upgraded 1.8.0 → 1.10.2, the full suite passes unchanged (1707), and pipeline-core's floor is raised `^1.8` → `^1.10.2` so nothing can resolve a stale one. The editable-worktree half remains: sibling repos are still installed from working trees, so a proof still validates whatever branch each happens to be on**), ~~plus the known `views-evaluation ^0.4.0 → ^0.5.0` bump awaiting the leaf release~~ — **DONE 2026-08-02**: views-evaluation 0.5.0 published to PyPI, pin bumped, and the adoption verified against the **published wheel** in a clean venv rather than the editable checkout: `to_metric_frame` present, all six kwargs `evaluation/stage.py` passes accepted, and a real 12-key combined config **accepted** by their new fail-loud validator.
 
 > **Strategic context (2026-06-19) — `views-frames` is coming.** A new leaf
 > data-contract package, `views_platform/views-frames` (scaffolded 2026-06-19,


### PR DESCRIPTION
`^1.8` accepted 1.10.2 — but it also accepted **1.8.0**, so nothing stopped a consumer resolving a version two minors behind what the platform actually runs. `^1.10.2` (Poetry for `>=1.10.2,<2.0.0`) makes the current version the minimum.

## Environment upgraded first, then the floor raised

A floor is only meaningful if the suite has run against it. The `views_pipeline` env went **1.8.0 → 1.10.2** and:

```
1707 passed, 24 skipped, 8 xfailed
```

**Two minor versions, zero breakage.** That is the useful signal for the other eight repos.

## The ceiling stays, deliberately

`<2.0.0` is what prevents a future views-frames **2.0.0** — which by SemVer is *permitted* to break its API — from installing itself automatically. Without it, the day 2.0.0 ships, every consumer picks it up on the next install.

That is the same shape as the two failures that cost this week: views-evaluation retiring a key pipeline-core kept sending, and `eval_type="long"` requesting 37 sequences the geometry allowed 13 of. Both were **an upstream change arriving somewhere that had not agreed to it.** The ceiling makes that arrival a decision.

## Release gate

Closes the **views-frames half of C-206** — the box no longer holds 1.8.0 while the train assumes 1.10.x.

The **editable-worktree half remains open** (#274): sibling repos are still installed from working trees, so a proof run still validates whatever branch each happens to be on.

## Platform note — not in this PR

8 other repos depend on views-frames, with floors ranging from **1.0 to 1.9**:

| Repo | Floor today |
|---|---|
| views-datafactory | 1.0 |
| views-postprocessing | 1.0 |
| views-reporting | 1.0.0 |
| views-baseline | 1.3.0 |
| views-faoapi | 1.3.0 |
| views-hydranet | 1.3 |
| views-evaluation | 1.4 |
| views-crafdapi | 1.9.0 |

Three of them would currently accept a version **ten minors old**. Those are the operator's to raise; this PR covers pipeline-core only.

## Verification

- `pytest tests/ -q` → **1707 passed, 24 skipped, 8 xfailed** — against 1.10.2
- `ruff check .` → clean · `validate_docs.sh` → clean · register count-gate green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
