### PR TITLE
docs(adr-054)!: record why no views-reporting floor is declared, and enforce it (#375)

### DIFF
--- a/documentation/ADRs/054_visualization_and_reporting_extraction.md
+++ b/documentation/ADRs/054_visualization_and_reporting_extraction.md
@@ -79,7 +79,46 @@ views_reporting/
 
 **Dependency direction constraint:** `views-reporting` depends on `views-pipeline-core` (for `_ViewsDataset`, `ModelPathManager`). Pipeline-core **NEVER** depends on views-reporting. The re-export shims use `try/except ImportError` — they provide a helpful error message but do not add views-reporting as an install dependency.
 
-**Version coordination:** `views-reporting` pins `views-pipeline-core >= 2.3.0, < 3.0.0`. A breaking change to `_ViewsDataset` interface requires a coordinated release with version bumps in both packages.
+**Version coordination:** `views-reporting` pins `views-pipeline-core >= 3.0.0, < 4.0.0` (0.3.1 on PyPI; it pinned `>= 2.3.0, < 3.0.0` when this ADR was written). A breaking change to the `_ViewsDataset` interface requires a coordinated release with version bumps in both packages.
+
+#### Amendment (2026-08-02, issue #375): no `views-reporting` floor will be declared
+
+Issue #375 proposed adding a `views-reporting` version floor to `pyproject.toml`, on the reasonable
+argument that a declared floor moves a dependency failure from run time to install time. **It was
+closed without adding one.** The reasoning is recorded here because the next contributor will have
+the same reasonable thought, and nothing in `pyproject.toml` would tell them why it is wrong.
+
+Declaring the floor would draw the second arrow in the dependency graph, turning a one-way
+relationship into a cycle. Three consequences follow, each verified rather than argued:
+
+1. **A major release could no longer be cut cleanly.** views-reporting 0.3.1 requires
+   `views-pipeline-core >= 3.0.0, < 4.0.0`. On the day pipeline-core cuts 4.0.0, its own declared
+   dependency becomes unsatisfiable against itself, and the resolver — not a human — decides what
+   happens next.
+2. **The platform's Python range would collapse to 3.11.** views-reporting 0.3.1 declares
+   `requires_python >= 3.11, < 3.12`; pipeline-core supports `>= 3.11, < 3.15`. A *required*
+   dependency's ceiling becomes ours, for all five consumers, including those that never render a
+   report. (views-reporting is widening this to `< 3.15` in 0.3.2; the structural point survives the
+   fix, because the ceiling is theirs to move and ours to inherit.)
+3. **It would contradict the constraint stated directly above** and break
+   `.github/workflows/run_pytest_minimal.yml`, the CI job that uninstalls views-reporting and reruns
+   the suite precisely to keep this rule true.
+
+**What guarantees correctness instead.** The four `views_reporting` imports in
+`managers/reporting/stage.py` are all inside functions, so importing pipeline-core loads nothing from
+views-reporting. Two capability probes — `_require_dense_report_consumer` and
+`_require_evaluation_source_consumer` — fail loud with remediation text when the installed build
+lacks a public symbol the dense report path needs. That is a *capability* check rather than a
+*version* check, which is the correct mechanism for a component consumed as a runtime plug-in.
+
+**The residual, tracked separately.** The probes fire at report generation, after training and
+inference, so an environment defect costs a run. Moving them to run preflight is the fix, and it does
+not require a pin.
+
+**Trigger to revisit.** If views-reporting ever stops depending on `views-pipeline-core` — the
+inversion sketched in the Decision-K shape already applied to reconciliation, where pipeline-core
+defines a Protocol and views-reporting implements it — the cycle argument disappears and a floor
+becomes both safe and correct. Until then, this ADR's constraint stands as written.
 
 **Integration branch:** All extraction PRs merge into `integration/views-reporting-extraction` before merging to `development`.
 

--- a/tests/test_falsification_views_reporting_dependency.py
+++ b/tests/test_falsification_views_reporting_dependency.py
@@ -105,15 +105,14 @@ class TestHardF5_ADR054DeclaresIntentionalNonDependency:
     Severity: Hard falsification — documentation directly contradicts the 'bug' framing.
     """
 
-    @pytest.mark.skip(reason="Falsification stub — ADR-054 governs this decision")
-    def test_adr054_declares_no_dependency_on_views_reporting(self):
-        # ADR-054 line 80: "Pipeline-core NEVER depends on views-reporting."
-        # This is a deliberate architectural decision, not a bug.
-        pass
-
-    @pytest.mark.skip(reason="Falsification stub — CI proves intentional support")
-    def test_ci_explicitly_tests_without_views_reporting(self):
-        # .github/workflows/run_pytest_minimal.yml:
-        #   "pip uninstall -y views-reporting ..."
-        #   "Run core-only tests (without views-reporting)"
-        pass
+    # ENFORCED, as of #375: the two stubs that used to sit here named this rule, cited
+    # ADR-054, and asserted nothing — `@pytest.mark.skip` with a body of `pass`. They
+    # reported the constraint as covered while permitting every way of breaking it.
+    #
+    # `tests/test_reporting_is_not_a_dependency.py` now checks it for real: no declared
+    # pin (in dependencies, extras or groups), no module-scope `views_reporting` import
+    # anywhere under the package (by AST), the ADR still stating the rule, and the
+    # minimal CI job still uninstalling views-reporting. All four are mutation-tested.
+    #
+    # The stubs are deleted rather than converted: a skipped test that duplicates a real
+    # one is worse than no test, because the summary line counts it as coverage.

--- a/tests/test_reporting_is_not_a_dependency.py
+++ b/tests/test_reporting_is_not_a_dependency.py
@@ -1,0 +1,177 @@
+"""ADR-054's dependency-direction rule, made executable.
+
+## The rule
+
+ADR-054 states it in one sentence:
+
+    views-reporting depends on views-pipeline-core. Pipeline-core NEVER depends on
+    views-reporting.
+
+## Why this file exists
+
+Until now that rule was **prose**. The two tests that claimed to enforce it
+(`test_falsification_views_reporting_dependency.py::TestHardF5_*`) were
+`@pytest.mark.skip` stubs whose bodies were `pass`. They named the rule, cited the ADR
+line, and asserted nothing — so a contributor could have declared the pin, moved an
+import to module scope, or deleted the CI job, and the suite would have stayed green
+while reporting that the constraint was covered.
+
+That is the shape views-evaluation registered as **C-36**: the policy that was supposed
+to supply an enforcement point supplied prose instead.
+
+Issue **#375** is what made this urgent. It proposed adding a `views-reporting` version
+floor to `pyproject.toml` — a reasonable-sounding change that would draw the second arrow
+in the dependency graph and turn a deliberate one-way relationship into a cycle. It was
+closed *without* adding the floor (ADR-054, amendment 2026-08-02). Closing an issue on
+the strength of a rule that nothing enforces is how the rule gets quietly reversed by the
+next person who has the same reasonable thought.
+
+## What each check defends, concretely
+
+* **No declared pin.** Declaring one means pipeline-core cannot cut a major version
+  without views-reporting's pin being satisfiable against it, and inherits
+  views-reporting's `requires_python` ceiling for every consumer — including those that
+  never render a report.
+* **No module-scope import.** The lazy imports are load-bearing, not stylistic. Hoisting
+  one to module scope makes `import views_pipeline_core` pull in a package that depends on
+  views_pipeline_core, which is a genuine circular import rather than a metadata concern.
+  Nothing else in the repo would catch it, because the dev environment has
+  views-reporting installed and the import would simply succeed.
+* **CI still runs without it.** `run_pytest_minimal.yml` uninstalls views-reporting and
+  reruns the suite. Deleting that step is the cheapest way to lose the guarantee.
+
+The import sites are **derived by walking the package's AST**, never listed. Every
+hand-maintained inventory in this repo has gone stale (C-259, C-261, C-264).
+"""
+
+from __future__ import annotations
+
+import ast
+import tomllib
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+PACKAGE_ROOT = REPO_ROOT / "views_pipeline_core"
+PYPROJECT = REPO_ROOT / "pyproject.toml"
+ADR_054 = REPO_ROOT / "documentation" / "ADRs" / "054_visualization_and_reporting_extraction.md"
+MINIMAL_CI = REPO_ROOT / ".github" / "workflows" / "run_pytest_minimal.yml"
+
+_FORBIDDEN_ROOT = "views_reporting"
+
+
+def _module_scope_reporting_imports() -> list[str]:
+    """Every `views_reporting` import that executes at module import time.
+
+    An import is module-scope when no enclosing function or class body contains it.
+    Walking the tree and recording the enclosing scope is what makes this derived
+    rather than a grep for indentation, which would be defeated by a nested `if`.
+    """
+    offenders: list[str] = []
+
+    for source_file in sorted(PACKAGE_ROOT.rglob("*.py")):
+        tree = ast.parse(source_file.read_text(), filename=str(source_file))
+
+        deferred: set[int] = set()
+        for node in ast.walk(tree):
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+                for descendant in ast.walk(node):
+                    deferred.add(id(descendant))
+
+        for node in ast.walk(tree):
+            if id(node) in deferred:
+                continue
+
+            names: list[str] = []
+            if isinstance(node, ast.ImportFrom) and node.module:
+                names = [node.module]
+            elif isinstance(node, ast.Import):
+                names = [alias.name for alias in node.names]
+
+            if any(n.split(".")[0] == _FORBIDDEN_ROOT for n in names):
+                relative = source_file.relative_to(REPO_ROOT)
+                offenders.append(f"{relative}:{node.lineno}")
+
+    return offenders
+
+
+def test_pyproject_declares_no_views_reporting_dependency() -> None:
+    """The pin #375 proposed must not appear — in dependencies, extras, or groups."""
+    raw = PYPROJECT.read_text()
+    data = tomllib.loads(raw)
+    poetry = data["tool"]["poetry"]
+
+    declared = set(poetry.get("dependencies", {}))
+    for group in poetry.get("group", {}).values():
+        declared |= set(group.get("dependencies", {}))
+
+    offending = {name for name in declared if name.replace("_", "-") == "views-reporting"}
+
+    assert not offending, (
+        f"pyproject.toml declares {sorted(offending)}. ADR-054: 'Pipeline-core NEVER "
+        f"depends on views-reporting.' Declaring it creates a package cycle — "
+        f"views-reporting already requires views-pipeline-core>=3.0.0,<4.0.0 — which "
+        f"blocks the next major release and imposes views-reporting's requires_python "
+        f"ceiling on every consumer. See ADR-054's 2026-08-02 amendment (issue #375). "
+        f"If the direction has genuinely been inverted, amend the ADR first."
+    )
+
+
+def test_no_views_reporting_import_runs_at_module_scope() -> None:
+    """Importing pipeline-core must not import a package that imports pipeline-core."""
+    offenders = _module_scope_reporting_imports()
+
+    assert not offenders, (
+        f"views_reporting is imported at module scope in: {offenders}. Those imports "
+        f"must stay inside the functions that use them. views-reporting depends on "
+        f"views-pipeline-core, so a module-scope import makes "
+        f"'import views_pipeline_core' circular. This will NOT fail in a dev "
+        f"environment, where views-reporting is installed and the import simply "
+        f"succeeds — it fails for consumers who installed neither."
+    )
+
+
+def test_the_import_guard_is_watching_real_import_sites() -> None:
+    """The AST guard must be pointed at code that actually imports views_reporting.
+
+    A guard that scans the wrong tree reports 'no offenders' forever. Four times in this
+    repo a guard has named its own scope and been wrong about it (C-259, C-261, C-264,
+    #346), so the population is asserted rather than assumed: there must be deferred
+    views_reporting imports somewhere, or this file is watching nothing.
+    """
+    deferred_sites = [
+        f"{path.relative_to(REPO_ROOT)}"
+        for path in PACKAGE_ROOT.rglob("*.py")
+        if _FORBIDDEN_ROOT in path.read_text()
+    ]
+
+    assert deferred_sites, (
+        "No file under views_pipeline_core/ mentions views_reporting at all. Either the "
+        "reporting stage was removed — in which case delete this file — or PACKAGE_ROOT "
+        "no longer points at the package and the module-scope guard is vacuous."
+    )
+
+
+def test_adr_054_still_states_the_rule_this_file_enforces() -> None:
+    """A guard outliving its rationale becomes folklore; fail if the ADR stops saying it."""
+    text = ADR_054.read_text()
+    assert "NEVER** depends on views-reporting" in text, (
+        f"{ADR_054.name} no longer states 'Pipeline-core NEVER depends on "
+        f"views-reporting'. If that decision was reversed, this file's checks are "
+        f"enforcing a rule the architecture has abandoned — delete them deliberately "
+        f"rather than leaving them to fail mysteriously."
+    )
+    assert "#375" in text, (
+        f"{ADR_054.name} no longer records the #375 amendment explaining why no floor "
+        f"is declared. Without it, the next contributor adds the pin in good faith."
+    )
+
+
+def test_ci_still_runs_the_suite_without_views_reporting() -> None:
+    """The minimal CI job is the only check that runs against a real absence."""
+    workflow = MINIMAL_CI.read_text()
+    assert "pip uninstall" in workflow and "views-reporting" in workflow, (
+        f"{MINIMAL_CI.name} no longer uninstalls views-reporting before running the "
+        f"suite. That job is what proves the lazy imports actually hold in an "
+        f"environment without views-reporting; the AST guard above only proves the "
+        f"source looks right."
+    )


### PR DESCRIPTION
Closes #375 — by deciding **not** to add the pin it proposed, and by making the rule that decision rests on executable for the first time.

## Why no floor

Declaring `views-reporting` in `pyproject.toml` would draw the second arrow in the dependency graph and turn a deliberate one-way relationship into a cycle. views-reporting 0.3.1 already requires `views-pipeline-core>=3.0.0,<4.0.0`.

Three consequences, each verified rather than argued:

1. **pipeline-core could not cut 4.0.0 cleanly** — its own declared dependency would become unsatisfiable against itself, and the resolver, not a human, would decide what happens.
2. **The platform's Python range would collapse to 3.11.** views-reporting 0.3.1 declares `requires_python >=3.11,<3.12` against our `>=3.11,<3.15`. A required dependency's ceiling becomes ours, for all five consumers — including those that never render a report.
3. **It would contradict ADR-054's stated constraint** and break `run_pytest_minimal.yml`, the CI job that exists to keep that constraint true.

### There is no cycle today — confirmed, not assumed

| Check | Result |
|---|---|
| `views-reporting` in `pyproject.toml` | **zero occurrences** |
| The four `views_reporting` imports in `managers/reporting/stage.py` | **all inside functions** (lines 40, 60, 121, 203/204) |
| `import views_pipeline_core` → loads views_reporting? | **no modules loaded** |
| Enforced in CI? | job literally named *"Tests (minimal — no views-reporting)"* |

## What enforces it now

The rule was prose. The two tests that claimed to enforce it were `@pytest.mark.skip` stubs with bodies of `pass` — they named the rule, cited ADR-054, asserted nothing, and **counted as coverage in the summary line**.

That is the shape views-evaluation registered as **C-36**: the policy meant to supply an enforcement point supplied prose instead. Closing an issue on the strength of an unenforced rule is how the rule gets quietly reversed by the next person who has the same reasonable thought #375 had.

`tests/test_reporting_is_not_a_dependency.py` checks four things for real:

- **no declared pin** — in `dependencies`, `extras` *or* groups
- **no module-scope `views_reporting` import** anywhere under the package, derived by walking the AST rather than grepping indentation (a nested `if` would defeat the grep), and never from a hand-listed inventory
- **ADR-054 still states the rule** and still records this amendment — a guard outliving its rationale becomes folklore
- **`run_pytest_minimal.yml` still uninstalls views-reporting** before running

### Mutation-tested, all four

| Mutation | Result |
|---|---|
| add `views-reporting = "^0.3.1"` to pyproject | 1 failed, 4 passed |
| hoist `from views_reporting.statistics import ...` to module scope | 1 failed, 4 passed |
| remove the ADR's rule sentence | 1 failed, 4 passed |
| delete the CI uninstall step | 1 failed, 4 passed |
| *(restored)* | **5 passed** |

Each kills exactly its own guard; nothing bleeds.

**The module-scope check is the one nothing else could catch.** It does *not* fail in a dev environment, where views-reporting is installed and the hoisted import simply succeeds. It fails for consumers who installed neither.

## Also in this PR

A stale line corrected: ADR-054 said views-reporting pins pipeline-core `>=2.3.0,<3.0.0`. On PyPI 0.3.1 it is `>=3.0.0,<4.0.0`.

## Residual, deliberately not fixed here

The capability probes fire at **report generation** — after training and inference — so an environment defect still costs a run. Moving them to preflight is the fix, and it needs no pin.

## Trigger to revisit

If views-reporting ever stops depending on views-pipeline-core — the Decision-K inversion already applied to reconciliation, where pipeline-core defines a Protocol and views-reporting implements it — the cycle argument disappears and a floor becomes both safe and correct.

## Verification

- `1724 passed, 22 skipped, 8 xfailed` (1719 + 5 new; skips 24 → 22 as the dead stubs go)
- `ruff check .` clean repo-wide

🤖 Generated with [Claude Code](https://claude.com/claude-code)
