### PR TITLE
fix(templates)!: generated run.sh declares bash, not zsh — and stops rewriting ~/.zshrc (#384)

### DIFF
--- a/tests/test_generated_run_scripts_are_portable.py
+++ b/tests/test_generated_run_scripts_are_portable.py
@@ -1,0 +1,211 @@
+"""Generated `run.sh` scripts must run where this platform actually runs. Issue #384.
+
+NOTE ON THE ID: the originating issue calls this "C-39", which is **views-models' register
+entry**, not this repo's. C-39 here is an unrelated concern about duplicated rolling-origin
+step-mapping. Registers are per-repo and their numbers collide; the shared identifier for
+this defect is issue #384.
+
+## The incident this guard closes
+
+views-models fixed it in its own tree on 2026-04-21 (`83fb3a2e`, *"replace #!/bin/zsh
+with #!/usr/bin/env bash in all 79 scripts"*) and marked the risk resolved. **It then
+regressed 24 times**, because the fix went to the *output* and not to the *generator*.
+Every regressed file postdates the fix: `first_love`, `bad_romance`, `smol_cat` (May 4),
+`fake_model` (May 19), the twelve r2darts models (June 28). The template here was last
+touched on 2026-04-03 — eighteen days *before* the fix — so every model scaffolded since
+was born with the defect.
+
+views-models has since added its own `tests/test_run_sh_portability.py`, which fails on any
+tracked `.sh` declaring zsh. That catches the next occurrence **after** a model has been
+scaffolded and committed. This file is what stops it being emitted in the first place.
+
+## Why zsh is wrong here
+
+zsh is not installed on Linux servers, Docker containers or CI runners, which is where
+this platform runs. `./run.sh` fails outright with
+`bad interpreter: /bin/zsh: No such file or directory`.
+
+The scripts were never really zsh anyway: the body called `eval "$(conda shell.bash hook)"`
+— the *bash* hook — under a zsh shebang. The interpreter declaration and the code it ran
+disagreed from the day it was written.
+
+## What this checks
+
+Both templates are **discovered by globbing** `templates/*/template_run_sh.py`, never
+listed. #384 named only the model template; the ensemble template carried the identical
+defect and went unmentioned — a hand-listed worklist missing a site is the failure mode
+this epic hit repeatedly (C-259, C-261, C-264).
+
+Each discovered template is invoked for real and its output checked:
+
+1. the shebang is `#!/usr/bin/env bash` — `env` rather than `/bin/bash`, because macOS
+   ships bash 3.2 at `/bin/bash` while Homebrew's modern bash lands on `PATH`;
+2. **`bash -n` parses the result** — the check that actually matters, since a shebang can
+   be changed without the body being valid bash;
+3. no generated script mutates `~/.zshrc` or sources it.
+
+Check 2 is the one that could fail for a reason we do not already believe. Checks 1 and 3
+only confirm the string we just wrote.
+"""
+
+from __future__ import annotations
+
+import importlib
+import inspect
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+TEMPLATES_ROOT = REPO_ROOT / "views_pipeline_core" / "templates"
+
+REQUIRED_SHEBANG = "#!/usr/bin/env bash"
+
+# Every kind of run-script generator in the package, found rather than named. A new
+# template family (a third alongside model/ and ensemble/) is covered the day it lands.
+RUN_SH_TEMPLATES = sorted(TEMPLATES_ROOT.glob("*/template_run_sh.py"))
+
+
+def _generate(template_path: Path, destination: Path) -> str:
+    """Invoke a template's `generate()` and return what it wrote.
+
+    The two templates have different signatures — the model one takes a package name,
+    the ensemble one hardcodes its environment — so the arguments are derived from the
+    signature rather than assumed. Assuming would make this guard silently skip whichever
+    template did not match the assumption.
+    """
+    family = template_path.parent.name
+    module = importlib.import_module(
+        f"views_pipeline_core.templates.{family}.template_run_sh"
+    )
+
+    parameters = list(inspect.signature(module.generate).parameters)
+    extra = {"package_name": f"views_{family}_probe"}
+    kwargs = {name: extra[name] for name in parameters[1:] if name in extra}
+
+    unsupported = [name for name in parameters[1:] if name not in extra]
+    assert not unsupported, (
+        f"{template_path.relative_to(REPO_ROOT)}::generate takes parameter(s) "
+        f"{unsupported} that this test does not know how to supply, so it would be "
+        f"skipped silently. Teach the test the new parameter."
+    )
+
+    module.generate(destination, **kwargs)
+    assert destination.exists(), (
+        f"{template_path.relative_to(REPO_ROOT)}::generate returned without writing "
+        f"{destination}. Nothing below can be checked."
+    )
+    return destination.read_text()
+
+
+def _ids() -> list[str]:
+    return [f"{p.parent.name}" for p in RUN_SH_TEMPLATES]
+
+
+@pytest.mark.parametrize("template_path", RUN_SH_TEMPLATES, ids=_ids())
+def test_generated_script_declares_a_portable_shebang(
+    template_path: Path, tmp_path: Path
+) -> None:
+    """zsh is absent on the Linux servers, containers and CI runners this platform uses."""
+    content = _generate(template_path, tmp_path / "run.sh")
+    first_line = content.splitlines()[0]
+
+    assert first_line == REQUIRED_SHEBANG, (
+        f"{template_path.relative_to(REPO_ROOT)} generates a script starting "
+        f"{first_line!r}. It must be {REQUIRED_SHEBANG!r}. zsh is not installed on the "
+        f"Linux servers, Docker containers and CI runners this platform runs on, so "
+        f"./run.sh fails with 'bad interpreter'. This regressed into 24 scaffolded models "
+        f"because it was fixed in the generated output and not in this generator (#384)."
+    )
+
+
+@pytest.mark.parametrize("template_path", RUN_SH_TEMPLATES, ids=_ids())
+def test_generated_script_actually_parses_as_bash(
+    template_path: Path, tmp_path: Path
+) -> None:
+    """The check that can fail for a reason we do not already believe.
+
+    Declaring bash in the shebang and emitting something bash cannot parse would leave
+    the scripts just as broken, in a way an assertion on the first line cannot see.
+    `bash -n` reads the whole script and reports syntax errors without executing a
+    single command, so this is safe to run against a generator's output.
+    """
+    destination = tmp_path / "run.sh"
+    _generate(template_path, destination)
+
+    result = subprocess.run(
+        ["bash", "-n", str(destination)], capture_output=True, text=True
+    )
+
+    assert result.returncode == 0, (
+        f"{template_path.relative_to(REPO_ROOT)} generates a script that bash cannot "
+        f"parse:\n{result.stderr}"
+    )
+
+
+@pytest.mark.parametrize("template_path", RUN_SH_TEMPLATES, ids=_ids())
+def test_generated_script_does_not_mutate_the_users_shell_profile(
+    template_path: Path, tmp_path: Path
+) -> None:
+    """A script named "run this model" must not rewrite the user's shell config.
+
+    With ~130 generated scripts per consuming repo, appending to `~/.zshrc` on every run
+    is a side effect no reader would predict. Sourcing it under a bash shebang is
+    additionally incoherent — it asks bash to read a zsh config, which on macOS can emit
+    syntax errors from zsh-only constructs.
+
+    The environment variables that block needed are exported directly instead, which
+    achieves the actual goal (libomp is findable for this run) without touching global
+    state that outlives the process.
+    """
+    content = _generate(template_path, tmp_path / "run.sh")
+
+    assert ">> ~/.zshrc" not in content, (
+        f"{template_path.relative_to(REPO_ROOT)} generates a script that appends to the "
+        f"user's ~/.zshrc. Export the variables in the script instead — the values are "
+        f"only needed for the run."
+    )
+    assert "source ~/.zshrc" not in content, (
+        f"{template_path.relative_to(REPO_ROOT)} generates a script that sources "
+        f"~/.zshrc under a bash shebang, asking bash to read a zsh config."
+    )
+
+
+@pytest.mark.parametrize("template_path", RUN_SH_TEMPLATES, ids=_ids())
+def test_template_source_neither_emits_nor_advertises_zsh(template_path: Path) -> None:
+    """Docstrings promising a zsh script are how the next contributor re-adds one.
+
+    This checks the two things that are actually wrong — a zsh shebang in the emitted
+    string, and a docstring describing the output as a zsh script — rather than banning
+    the substring "zsh" outright. A blanket ban would forbid the docstring note that
+    warns future contributors OFF zsh, which is the opposite of the intent, and is the
+    same mistake as a guard that names its own scope wrongly (C-259, C-261, C-264).
+    """
+    source = template_path.read_text()
+
+    assert "#!/bin/zsh" not in source, (
+        f"{template_path.relative_to(REPO_ROOT)} emits a zsh shebang — the defect that "
+        f"regressed into 24 scaffolded models (#384)."
+    )
+    assert "executed in a zsh shell" not in source, (
+        f"{template_path.relative_to(REPO_ROOT)}'s docstring still describes the "
+        f"generated script as a zsh script. That description is an instruction to "
+        f"whoever edits it next."
+    )
+
+
+def test_the_guard_found_every_run_script_generator() -> None:
+    """A parametrized test over an empty list reports as passing.
+
+    #384 named one template; there were two. This asserts the discovery glob found both
+    families that exist today, so a guard watching nothing cannot masquerade as a guard
+    watching everything.
+    """
+    families = {p.parent.name for p in RUN_SH_TEMPLATES}
+    assert {"model", "ensemble"} <= families, (
+        f"Expected run-script templates for at least the model and ensemble families; "
+        f"found {sorted(families) or 'none'} under {TEMPLATES_ROOT}. Either a template "
+        f"was moved or the discovery glob is wrong — in both cases this file is now "
+        f"checking less than it appears to."
+    )

--- a/views_pipeline_core/templates/ensemble/template_run_sh.py
+++ b/views_pipeline_core/templates/ensemble/template_run_sh.py
@@ -5,7 +5,7 @@ def generate(script_path: Path) -> bool:
     Generates a shell script to set up the environment and run a Python script.
 
     This function creates a shell script that:
-    - Checks if the operating system is macOS (Darwin) and updates the user's `.zshrc` file with necessary environment variables for `libomp`.
+    - Checks if the operating system is macOS (Darwin) and exports the environment variables `libomp` needs, for the duration of the run only.
     - Determines the script's directory and the project's root directory.
     - Sets up the path for the Conda environment specific to the project.
     - Activates the Conda environment if it exists, or creates a new one if it doesn't.
@@ -21,7 +21,7 @@ def generate(script_path: Path) -> bool:
             True if the script was successfully written to the specified directory, False otherwise.
 
     The generated shell script includes the following steps:
-    - Checks if the operating system is macOS and updates the `.zshrc` file with necessary environment variables for `libomp`.
+    - Checks if the operating system is macOS and exports the environment variables `libomp` needs, for the duration of the run only.
     - Determines the script's directory and the project's root directory.
     - Sets up the path for the Conda environment specific to the project.
     - Activates the Conda environment if it exists, or creates a new one if it doesn't.
@@ -30,21 +30,20 @@ def generate(script_path: Path) -> bool:
 
     Note:
         - Ensure that the `requirements.txt` file is present in the same directory as the generated shell script.
-        - The generated shell script is designed to be executed in a zsh shell.
+        - The generated shell script declares `#!/usr/bin/env bash` and is checked by
+          `tests/test_generated_run_scripts_are_portable.py` (issue #384).
+          It must not be changed to zsh: zsh is absent on the Linux servers, Docker
+          containers and CI runners this platform runs on.
     """
-    code = """#!/bin/zsh
+    code = """#!/usr/bin/env bash
 
 if [[ "$OSTYPE" == "darwin"* ]]; then
-  if ! grep -q 'export LDFLAGS="-L/opt/homebrew/opt/libomp/lib"' ~/.zshrc; then
-    echo 'export LDFLAGS="-L/opt/homebrew/opt/libomp/lib"' >> ~/.zshrc
-  fi
-  if ! grep -q 'export CPPFLAGS="-I/opt/homebrew/opt/libomp/include"' ~/.zshrc; then
-    echo 'export CPPFLAGS="-I/opt/homebrew/opt/libomp/include"' >> ~/.zshrc
-  fi
-  if ! grep -q 'export DYLD_LIBRARY_PATH="/opt/homebrew/opt/libomp/lib:$DYLD_LIBRARY_PATH"' ~/.zshrc; then
-    echo 'export DYLD_LIBRARY_PATH="/opt/homebrew/opt/libomp/lib:$DYLD_LIBRARY_PATH"' >> ~/.zshrc
-  fi
-  source ~/.zshrc
+  # libomp sits in Homebrew's prefix on macOS and is not on the default search paths.
+  # Exported for THIS run only: the values are needed while the ensemble runs, and a
+  # script named "run this ensemble" should not rewrite the user's shell profile (#384).
+  export LDFLAGS="-L/opt/homebrew/opt/libomp/lib $LDFLAGS"
+  export CPPFLAGS="-I/opt/homebrew/opt/libomp/include $CPPFLAGS"
+  export DYLD_LIBRARY_PATH="/opt/homebrew/opt/libomp/lib:$DYLD_LIBRARY_PATH"
 fi
 
 script_path=$(dirname "$(realpath $0)")

--- a/views_pipeline_core/templates/model/template_run_sh.py
+++ b/views_pipeline_core/templates/model/template_run_sh.py
@@ -5,7 +5,7 @@ def generate(script_path: Path, package_name: str) -> bool:
     Generates a shell script to set up the environment and run a Python script.
 
     This function creates a shell script that:
-    - Checks if the operating system is macOS (Darwin) and updates the user's `.zshrc` file with necessary environment variables for `libomp`.
+    - Checks if the operating system is macOS (Darwin) and exports the environment variables `libomp` needs, for the duration of the run only.
     - Determines the script's directory and the project's root directory.
     - Sets up the path for the Conda environment specific to the project.
     - Activates the Conda environment if it exists, or creates a new one if it doesn't.
@@ -23,7 +23,7 @@ def generate(script_path: Path, package_name: str) -> bool:
             True if the script was successfully written to the specified directory, False otherwise.
 
     The generated shell script includes the following steps:
-    - Checks if the operating system is macOS and updates the `.zshrc` file with necessary environment variables for `libomp`.
+    - Checks if the operating system is macOS and exports the environment variables `libomp` needs, for the duration of the run only.
     - Determines the script's directory and the project's root directory.
     - Sets up the path for the Conda environment specific to the project.
     - Activates the Conda environment if it exists, or creates a new one if it doesn't.
@@ -32,21 +32,20 @@ def generate(script_path: Path, package_name: str) -> bool:
 
     Note:
         - Ensure that the `requirements.txt` file is present in the same directory as the generated shell script.
-        - The generated shell script is designed to be executed in a zsh shell.
+        - The generated shell script declares `#!/usr/bin/env bash` and is checked by
+          `tests/test_generated_run_scripts_are_portable.py` (issue #384).
+          It must not be changed to zsh: zsh is absent on the Linux servers, Docker
+          containers and CI runners this platform runs on.
     """
-    code = f"""#!/bin/zsh
+    code = f"""#!/usr/bin/env bash
 
 if [[ "$OSTYPE" == "darwin"* ]]; then
-  if ! grep -q 'export LDFLAGS="-L/opt/homebrew/opt/libomp/lib"' ~/.zshrc; then
-    echo 'export LDFLAGS="-L/opt/homebrew/opt/libomp/lib"' >> ~/.zshrc
-  fi
-  if ! grep -q 'export CPPFLAGS="-I/opt/homebrew/opt/libomp/include"' ~/.zshrc; then
-    echo 'export CPPFLAGS="-I/opt/homebrew/opt/libomp/include"' >> ~/.zshrc
-  fi
-  if ! grep -q 'export DYLD_LIBRARY_PATH="/opt/homebrew/opt/libomp/lib:$DYLD_LIBRARY_PATH"' ~/.zshrc; then
-    echo 'export DYLD_LIBRARY_PATH="/opt/homebrew/opt/libomp/lib:$DYLD_LIBRARY_PATH"' >> ~/.zshrc
-  fi
-  source ~/.zshrc
+  # libomp sits in Homebrew's prefix on macOS and is not on the default search paths.
+  # Exported for THIS run only: the values are needed while the model runs, and a
+  # script named "run this model" should not rewrite the user's shell profile (#384).
+  export LDFLAGS="-L/opt/homebrew/opt/libomp/lib $LDFLAGS"
+  export CPPFLAGS="-I/opt/homebrew/opt/libomp/include $CPPFLAGS"
+  export DYLD_LIBRARY_PATH="/opt/homebrew/opt/libomp/lib:$DYLD_LIBRARY_PATH"
 fi
 
 script_path=$(dirname "$(realpath $0)")


### PR DESCRIPTION
Closes #384.

## The defect

zsh is not installed on the Linux servers, Docker containers and CI runners this platform runs on. A generated `./run.sh` fails with `bad interpreter: /bin/zsh: No such file or directory`.

views-models fixed this **in its own tree** on 2026-04-21 (`83fb3a2e`, 79 scripts) and marked it resolved. It then regressed **24 times**, because the fix went to the *output* and not to the *generator*. Every regressed file postdates that fix; this template was last touched 2026-04-03, eighteen days before it.

## Two templates, not one

#384 named `templates/model/template_run_sh.py`. **`templates/ensemble/template_run_sh.py` carried the identical defect** and went unmentioned — the two files are byte-identical apart from the environment path.

So the tests discover generators by globbing `templates/*/template_run_sh.py` rather than naming them. A third template family is covered the day it lands. Hand-listed worklists missing a site is the failure mode this epic hit repeatedly (C-259, C-261, C-264).

## The scripts were never really zsh

The body called `eval "$(conda shell.bash hook)"` — the **bash** hook — under a zsh shebang. The interpreter declaration and the code it ran disagreed from the day it was written.

Evidence: `bash -n` parses the *pre-change* body cleanly. The shebang was the only thing wrong.

`/usr/bin/env bash` rather than `/bin/bash`, because macOS ships bash 3.2 at `/bin/bash` while Homebrew's modern bash lands on `PATH`.

## Also fixed, because the shebang change made it worse

The macOS block appended three exports to the user's `~/.zshrc` and then `source`d it. Under a bash shebang that asks bash to read a zsh config — on macOS that can emit syntax errors from zsh-only constructs. Leaving it would have meant a portability fix that degraded something else.

```diff
-  if ! grep -q 'export LDFLAGS="..."' ~/.zshrc; then
-    echo 'export LDFLAGS="..."' >> ~/.zshrc
-  fi
-  ... (x3)
-  source ~/.zshrc
+  export LDFLAGS="-L/opt/homebrew/opt/libomp/lib $LDFLAGS"
+  export CPPFLAGS="-I/opt/homebrew/opt/libomp/include $CPPFLAGS"
+  export DYLD_LIBRARY_PATH="/opt/homebrew/opt/libomp/lib:$DYLD_LIBRARY_PATH"
```

Same effect for the run; no mutation of global state that outlives the process. A script named "run this model" should not rewrite the user's shell profile — and with ~130 generated scripts per consuming repo, that side effect is one no reader would predict.

**One correction to the issue text:** the block is wrapped in `if [[ "$OSTYPE" == "darwin"* ]]`, so it did not run "on every run, from every generated script" — only on macOS. That weakens the urgency but not the argument.

## The guard

`tests/test_generated_run_scripts_are_portable.py` — five checks per discovered template.

The one that **could fail for a reason we do not already believe** is `bash -n` on the generated output. A shebang can be corrected without the body being valid bash, and an assertion on the first line cannot see that. The other checks only confirm the string we just wrote.

### Mutation-tested, four ways

| Mutation | Result |
|---|---|
| revert **only** the model shebang | exactly `[model]` red, `[ensemble]` green |
| inject a bash syntax error | only the `bash -n` check red |
| re-add the `~/.zshrc` append | only the shell-profile check red |
| point the discovery glob at nothing | population check red, **rest SKIPPED** |

That last row is why the population check exists: an empty parametrize list does not pass, it *disappears*. A guard watching nothing must not look like a guard watching everything.

### A finding against my own first draft

The initial guard asserted `"zsh" not in source`. That would have forbidden the docstring note warning future contributors *off* zsh — the guard banning its own documentation. It now checks the two things actually wrong: a `#!/bin/zsh` in the emitted string, and a docstring describing the output as a zsh script.

## ID collision, disambiguated

#384 calls this "C-39", which is **views-models' register entry**. C-39 in *this* repo is an unrelated concern about duplicated rolling-origin step-mapping. Registers are per-repo and their numbers collide; the shared identifier is issue #384. Noted in the test docstring so nobody follows the wrong entry.

## Verification

- `1733 passed, 22 skipped, 8 xfailed` (1724 + 9 new)
- `ruff check .` clean repo-wide
- Generated output inspected by hand for both families

🤖 Generated with [Claude Code](https://claude.com/claude-code)
