### PR TITLE
chore(release)!: prepare 3.0.0 — packaging, metadata, changelog, and a proof check that derives its own scope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,132 @@
+# Changelog
+
+All notable changes to `views-pipeline-core`.
+
+This file did not exist before 3.0.0. It exists now because 3.0.0 carries **sixteen
+breaking changes across 185 commits**, and without it the only record of what broke would
+have been a commit log. Precedent and rationale: `views-evaluation/CHANGELOG.md`, created
+for the same reason after their 0.4.0 shipped breaking changes unannounced.
+
+Format follows [Keep a Changelog](https://keepachangelog.com/); this project uses
+[semantic versioning](https://semver.org/).
+
+> **Baseline note.** The previous published release is **2.3.0** (PyPI, 2026-05-18). A
+> `2.3.1` git tag existed but pointed at a commit whose `pyproject.toml` still read
+> `2.3.0`; it was never published and has been deleted. **There is no 2.3.1.**
+
+---
+
+## [3.0.0] — 2026-08-03
+
+A major release. Every item under *Removed* and *Changed — breaking* will break a 2.x
+consumer that touches it. The engine repos (views-hydranet, views-baseline) and
+views-reporting are already migrated and pin `>=3.0.0,<4.0.0`.
+
+### Removed
+
+- **The four ADR-054 re-export shims** — `modules/{statistics,visualizations,mapping,reports}`.
+  These functions live in **views-reporting**; import them from there. An org-wide search
+  found zero remaining consumers before removal. (#318)
+- **Session authentication** for Appwrite — `SessionAuth` and the four account/session
+  operations. Nothing constructed it. (#344)
+- **`eval_type="long"`.** It requested 37 rolling-origin sequences while the enforced
+  partition geometry supplies 13, so step-wise evaluation silently reported **12 of 36
+  steps**. Use `"standard"`. (#379)
+- **The synthesized `targets` config key.** pipeline-core manufactured it from
+  `regression_targets + classification_targets` for every model; views-evaluation retired
+  it and now raises on it, which broke every evaluation run. Read the split keys, or call
+  `configuration.combined_targets(config)`. (#381)
+- **The ambient `.env` load.** Credentials no longer arrive by omission;
+  `AppwriteConfig` is frozen. (#346)
+- **57 MB of shapefiles and header images** from the wheel — they moved to views-reporting
+  under ADR-054 and were never deleted here. The wheel is **60 MB → 1.2 MB unpacked**.
+  Nothing in this package referenced them. (#389)
+- **`pytest` as a runtime dependency.** Every consumer was installing a test framework it
+  never imports. It is now in the dev group; `poetry install` still provides it.
+
+### Changed — breaking
+
+- **`PredictionFrame` is now the views-frames leaf class.** The constructor takes
+  `PredictionFrame(y_pred, SpatioTemporalIndex(time, unit, level))`; the value accessor is
+  **`.values`**, not `.y_pred`; `collapse()` moved to `views_frames_summarize.collapse`.
+  This is the change that forced the major bump. (#188, #206)
+- **`modules/appwrite/reconcile/` → `modules/appwrite/audit/`**, with `reconcile()` →
+  `audit()` and `ReconciliationReport` → `AuditReport`. `reconcile` already meant CM↔PGM
+  hierarchical alignment in this codebase; two live meanings for one identifier is a trap.
+  The CLI is now `python -m views_pipeline_core.modules.appwrite.audit`. (#390)
+- **The Appwrite SDK is an optional extra.** Install `views-pipeline-core[appwrite]` if you
+  deliver to the FAO API. Three repos containing zero Appwrite references were installing
+  the SDK transitively. (#345)
+- **`views-evaluation` floor raised to `^1.0.0`.** The previous `^0.5.0` capped at `<0.6.0`
+  — Poetry bounds a `0.x` caret at the next *minor* — so the suite had drifted to a version
+  our own metadata forbade. Now guarded by a test. (#385)
+- **Generated `run.sh` declares `#!/usr/bin/env bash`, not `#!/bin/zsh`.** zsh is absent on
+  the Linux servers, containers and CI runners this platform runs on. The scripts were
+  never really zsh — the body already called the *bash* conda hook. The macOS block also
+  stops appending to `~/.zshrc`. (#384)
+- **No `views-reporting` version floor is declared, deliberately.** views-reporting depends
+  on *us*, so a floor would make the dependency cyclic and inherit their ceilings on their
+  release schedule. Runtime capability probes fail loud instead. Recorded in ADR-054 and
+  enforced by `tests/test_reporting_is_not_a_dependency.py`. (#375, #386)
+
+### Added
+
+- **FeatureFrame input path** — `get_feature_frame`, descriptor-declared dataframe-vs-frame
+  dispatch at the fetch choke point, a leaf-owned directory cache with retire-swap writes,
+  and `CoreFrameSniffer` for frame-native partition audit. (epic #285: #286–#290)
+- **Frame-native evaluation actuals** — `from_actual_arrays`, so frame-fed models evaluate
+  without pandas being touched. (epic #300: #301, #302)
+- **The datafactory consumer contract** — vendored conformance fixture plus loud runtime
+  validation. (#162)
+- **Reconciliation decoupled from views-reporting** via a DIP port and injected adapter.
+  (#195, #217)
+- **Sampled-forecast publish leg (PFE)** — the Hop-A publish path, golden-fixture wire
+  conformance, and a fail-loud `sample_count` guard. (#269, #160)
+- **A pandas-free base-manager import graph** — lazy facades, preflight, and a permanent
+  purity guard. (#320)
+- **Network timeouts on every Appwrite call**, with the hang path drilled first — an
+  unbounded call previously hung a delivery indefinitely. (#347)
+- **The Cluster J read-completeness guard** — a partial or failed read must not be usable
+  as an answer, enforced by AST at authoring time. (#343)
+- **A recorded-response fixture** captured from the live Appwrite service, replacing tests
+  that could only agree with their own mocks. (#348)
+- **PyPI metadata** — description, licence, repository and classifiers. Every release up to
+  2.3.0 published with all of these blank.
+
+### Fixed
+
+- **`get_latest_file_id` returned the newest of the *oldest 25* matches.** The metadata
+  search was unpaged, so the FAO delivery could ship a **stale run rather than failing**.
+  The search now pages, terminates on an empty page, and is certified against the total the
+  service reports. A failed read raises instead of returning `[]`. *(Tier 1)* (#341)
+- **A failed read was reported as absence** in the deduplication fallback walk, answering
+  `NOT_FOUND` from an incomplete listing. *(Tier 1)* (#358)
+- **The audit printed a conclusion above, and independent of, its own incompleteness
+  warning** — including the sentence that licenses deleting a production bucket. Rendering
+  now refuses to interpret while the read is known incomplete. *(Tier 1)* (#342)
+- **Appwrite upload failures were reported in-band and discarded**, with both call sites
+  logging unconditional success over a half-succeeded write. *(Tier 1)* (#329, #330, #331)
+- **Production coordinates were reachable by omission** — a missing environment variable
+  fell back to production defaults. (#324)
+- **`priogrid_gid` → `priogrid_id`** normalised at a single seam.
+- **Ensemble forecast cache** now regenerates when a constituent's sample count no longer
+  matches its config, and fails loud when a constituent produces the wrong count. (C-85)
+
+### Known limitations
+
+- **Tested on Python 3.11 only.** The declared range is `>=3.11,<3.15` to match the
+  platform envelope, but 3.12–3.14 installs *resolve* and then fail loudly at **build**
+  time in the transitive chain (`ingester3 =2.1.1 → levenshtein 0.20.9` has no wheel past
+  cp311; `pandas<2.0` likewise). The fix is upstream. Poetry derives
+  `Programming Language :: Python :: 3.12/3.13/3.14` classifiers from that range
+  automatically — treat `Requires-Python` as the binding statement, not the classifiers.
+- **No enforcement that a breaking public-symbol change forces a major bump.** This release
+  *is* that event, and the bump was reasoned by hand. Consciously accepted; the guard lands
+  in 3.0.1. (#374)
+
+---
+
+## [2.3.0] — 2026-05-18
+
+Last release before the ADR-054 extraction and the views-frames leaf adoption. See the
+GitHub release history for earlier versions; this file begins at 3.0.0.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,33 +2,46 @@
 
 All notable changes to `views-pipeline-core`.
 
-This file did not exist before 3.0.0. It exists now because 3.0.0 carries **sixteen
-breaking changes across 185 commits**, and without it the only record of what broke would
-have been a commit log. Precedent and rationale: `views-evaluation/CHANGELOG.md`, created
+This file did not exist before 3.0.0. It exists now because 3.0.0 is a major release and
+without it the only record of what broke would have been a commit log.
+
+`git log 2.3.0..development --no-merges` counts **185 commits**, of which **16 carry the
+conventional-commit `!` breaking marker**. This changelog lists **13** consumer-facing
+breaking entries: two of the sixteen are not consumer-visible (adopting views-evaluation
+0.5.0, superseded days later by the `^1.0.0` floor; and a documentation-only ADR
+amendment), and one entry below covers two commits. Precedent and rationale: `views-evaluation/CHANGELOG.md`, created
 for the same reason after their 0.4.0 shipped breaking changes unannounced.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/); this project uses
 [semantic versioning](https://semver.org/).
 
-> **Baseline note.** The previous published release is **2.3.0** (PyPI, 2026-05-18). A
-> `2.3.1` git tag existed but pointed at a commit whose `pyproject.toml` still read
-> `2.3.0`; it was never published and has been deleted. **There is no 2.3.1.**
+> **Baseline note.** The previous published release is **2.3.0** (PyPI, 2026-05-18).
+> **There is no 2.3.1.** A 2.3.1 tag and GitHub Release were created the same day, and the
+> publish workflow *did* run — it failed its own version guard, because `pyproject.toml` at
+> that commit still read `2.3.0`. The Release was reverted to a draft and the tag has now
+> been deleted. Nothing was ever uploaded to PyPI under that number.
 
 ---
 
 ## [3.0.0] — 2026-08-03
 
 A major release. Every item under *Removed* and *Changed — breaking* will break a 2.x
-consumer that touches it. The engine repos (views-hydranet, views-baseline) and
-views-reporting are already migrated and pin `>=3.0.0,<4.0.0`.
+consumer that touches it. views-baseline and views-reporting pin `>=3.0.0,<4.0.0`.
+views-hydranet pins it on `development`; its **default branch `main` still caps at
+`<3.0.0`** and will not receive this release until that merges. (Found by review — the
+claim originally read "already migrated", formed by reading a local checkout that happens
+to sit on `development`. That is the editable-worktree blind spot C-206 names, committed
+while describing the release that documents it.)
 
 ### Removed
 
 - **The four ADR-054 re-export shims** — `modules/{statistics,visualizations,mapping,reports}`.
   These functions live in **views-reporting**; import them from there. An org-wide search
   found zero remaining consumers before removal. (#318)
-- **Session authentication** for Appwrite — `SessionAuth` and the four account/session
-  operations. Nothing constructed it. (#344)
+- **Session authentication** for Appwrite — `SessionAuth` and **three** account/session
+  operations. Nothing constructed it. (A fourth, `users.get_prefs`, was grouped with them
+  in the issue title but is reached on the API-key path and survives — see
+  `tests/test_modules/test_session_auth_is_gone.py`.) (#344 → #359)
 - **`eval_type="long"`.** It requested 37 rolling-origin sequences while the enforced
   partition geometry supplies 13, so step-wise evaluation silently reported **12 of 36
   steps**. Use `"standard"`. (#379)
@@ -39,8 +52,10 @@ views-reporting are already migrated and pin `>=3.0.0,<4.0.0`.
 - **The ambient `.env` load.** Credentials no longer arrive by omission;
   `AppwriteConfig` is frozen. (#346)
 - **57 MB of shapefiles and header images** from the wheel — they moved to views-reporting
-  under ADR-054 and were never deleted here. The wheel is **60 MB → 1.2 MB unpacked**.
-  Nothing in this package referenced them. (#389)
+  under ADR-054 and were never deleted here. Download **7.3 MB → 0.4 MB**; unpacked
+  **60.2 MB → 1.2 MB**. No *code* referenced them, but `README.md` did — an `<img>` tag
+  pointing at a deleted file, which would have rendered broken on the PyPI page this
+  release exists to populate. Removed here. (#389)
 - **`pytest` as a runtime dependency.** Every consumer was installing a test framework it
   never imports. It is now in the dev group; `poetry install` still provides it.
 
@@ -75,7 +90,7 @@ views-reporting are already migrated and pin `>=3.0.0,<4.0.0`.
   dispatch at the fetch choke point, a leaf-owned directory cache with retire-swap writes,
   and `CoreFrameSniffer` for frame-native partition audit. (epic #285: #286–#290)
 - **Frame-native evaluation actuals** — `from_actual_arrays`, so frame-fed models evaluate
-  without pandas being touched. (epic #300: #301, #302)
+  without pandas being touched. (#301, #302; epic #300 remains open)
 - **The datafactory consumer contract** — vendored conformance fixture plus loud runtime
   validation. (#162)
 - **Reconciliation decoupled from views-reporting** via a DIP port and injected adapter.
@@ -84,19 +99,27 @@ views-reporting are already migrated and pin `>=3.0.0,<4.0.0`.
   conformance, and a fail-loud `sample_count` guard. (#269, #160)
 - **A pandas-free base-manager import graph** — lazy facades, preflight, and a permanent
   purity guard. (#320)
-- **Network timeouts on every Appwrite call**, with the hang path drilled first — an
-  unbounded call previously hung a delivery indefinitely. (#347)
+- **Network timeouts on every Appwrite call.** The hang path was drilled before a value
+  was chosen: a transport that never returns was installed and every Appwrite path stayed
+  blocked with no timeout, no error and no recovery. No delivery is on record as having
+  hung — the drill establishes that one *could have*, indefinitely. (#347)
 - **The Cluster J read-completeness guard** — a partial or failed read must not be usable
   as an answer, enforced by AST at authoring time. (#343)
 - **A recorded-response fixture** captured from the live Appwrite service, replacing tests
   that could only agree with their own mocks. (#348)
-- **PyPI metadata** — description, licence, repository and classifiers. Every release up to
-  2.3.0 published with all of these blank.
+- **PyPI metadata** — summary, licence and repository/homepage URLs, all of which were
+  blank on every release up to and including 2.3.0 (`summary: None`, `license: None`,
+  `project_urls: None`). Classifiers were **not** blank: Poetry has always derived them
+  from `requires-python`. The `LICENSE` file (MIT) had been in the repository the whole
+  time and was never declared, so the published artifact did not state its own licence.
 
 ### Fixed
 
 - **`get_latest_file_id` returned the newest of the *oldest 25* matches.** The metadata
-  search was unpaged, so the FAO delivery could ship a **stale run rather than failing**.
+  search was unpaged, so a delivery could ship a **stale run rather than failing**. Affected
+  set: this package, and views-postprocessing by inheritance — **not** views-faoapi, which
+  keeps its own correctly-paged copy. Reachability depends on a matching-document count
+  above 25 and was never confirmed against production.
   The search now pages, terminates on an empty page, and is certified against the total the
   service reports. A failed read raises instead of returning `[]`. *(Tier 1)* (#341)
 - **A failed read was reported as absence** in the deduplication fallback walk, answering
@@ -105,12 +128,22 @@ views-reporting are already migrated and pin `>=3.0.0,<4.0.0`.
   warning** — including the sentence that licenses deleting a production bucket. Rendering
   now refuses to interpret while the read is known incomplete. *(Tier 1)* (#342)
 - **Appwrite upload failures were reported in-band and discarded**, with both call sites
-  logging unconditional success over a half-succeeded write. *(Tier 1)* (#329, #330, #331)
+  logging unconditional success over a half-succeeded write. *(Tier 1, C-227)* (#330)
+- **A failed bucket read was treated as proof of absence, and absence triggered a
+  destructive metadata delete.** *(Tier 1, C-231)* (#329)
+- **A failed duplicate lookup was reported as "no duplicate"**, turning a read fault into a
+  duplicate write. *(Tier 1, C-232)* (#329)
+- **A wrong or stale bucket coordinate silently provisioned new production storage.** The
+  auto-create-and-retry is gone; a missing bucket now fails. Consumers relying on
+  provisioning-by-accident will see a failure where they previously saw success.
+  *(Tier 1, C-228)* (#331)
 - **Production coordinates were reachable by omission** — a missing environment variable
   fell back to production defaults. (#324)
 - **`priogrid_gid` → `priogrid_id`** normalised at a single seam.
 - **Ensemble forecast cache** now regenerates when a constituent's sample count no longer
-  matches its config, and fails loud when a constituent produces the wrong count. (C-85)
+  matches its config, and fails loud when a constituent produces the wrong count. (The
+  source cites register `C-85` in six places; that entry is about EnsembleManager test
+  coverage and is the wrong ID. Left uncorrected here rather than guessed at.)
 
 ### Known limitations
 
@@ -121,8 +154,8 @@ views-reporting are already migrated and pin `>=3.0.0,<4.0.0`.
   `Programming Language :: Python :: 3.12/3.13/3.14` classifiers from that range
   automatically — treat `Requires-Python` as the binding statement, not the classifiers.
 - **No enforcement that a breaking public-symbol change forces a major bump.** This release
-  *is* that event, and the bump was reasoned by hand. Consciously accepted; the guard lands
-  in 3.0.1. (#374)
+  *is* that event, and the bump was reasoned by hand. Consciously accepted for this
+  release; the guard is tracked in #374 and is not yet scheduled. (#374)
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -8,10 +8,6 @@
 </div>
 
 <p align="center">
-  <img src="views_pipeline_core/assets/vpc_header.png" alt="VIEWS Pipeline Core Banner" width="85%">
-</p>
-
-<p align="center">
   <img src="https://img.shields.io/github/license/views-platform/views-pipeline-core" alt="GitHub License" />
   &nbsp;&nbsp;
   <img src="https://img.shields.io/github/check-runs/views-platform/views-pipeline-core/main" alt="GitHub branch check runs" />

--- a/documentation/guides/publishing-to-pypi.md
+++ b/documentation/guides/publishing-to-pypi.md
@@ -5,7 +5,8 @@ Every command is copy-pasteable; the *why* is spelled out where getting it wrong
 expensive.
 
 > **Last verified:** 2026-08-03, preparing `3.0.0`. Mechanism confirmed against
-> views-evaluation 1.0.0, which shipped 2026-08-02 through a byte-identical workflow file.
+> views-evaluation 1.0.0, which shipped 2026-08-02 through a mechanism-identical workflow
+> file (it differs only in the package name inside the version-guard URL).
 > Companion documents: `CHANGELOG.md` (what changed), the release gate in
 > `reports/technical_risk_register.md` (what must be closed or consciously accepted first).
 
@@ -24,9 +25,15 @@ on:
 — a *published GitHub Release*, or a manual dispatch. Pushing `git tag 3.0.0 && git push
 --tags` and waiting will wait forever.
 
-The proof is in this repo's own history: a `2.3.1` tag existed on `main` for months,
-pointing at a commit whose `pyproject.toml` still said `2.3.0`. It was never published,
-because a tag was all it ever was. (It has since been deleted.)
+> **2.3.1 is NOT the proof of this** — an earlier draft of this guide said it was and had
+> the causality backwards. What actually happened on 2026-05-18: a tag *and* a Release were
+> created, the workflow **did** fire, and it failed its own version guard because
+> `pyproject.toml` at that commit still read `2.3.0`. The Release was then reverted to a
+> draft. So 2.3.1 is evidence that **the version guard works**, not that tags are inert.
+>
+> The tag has since been deleted. **The draft Release still exists** — which makes the
+> first row of the troubleshooting table below dangerous: publishing that draft re-fires a
+> run guaranteed to fail.
 
 ---
 
@@ -41,14 +48,20 @@ git commit -am "release: X.Y.Z" && git push   # PR -> merge to development -> me
 # 2. Cut the GitHub Release FROM main. THIS is what publishes.
 gh release create X.Y.Z --target main \
     --title "views-pipeline-core X.Y.Z" \
-    --notes-file <(sed -n '/## \[X.Y.Z\]/,/^## \[/p' CHANGELOG.md)
+    --notes-file <(sed -n '/## \[X.Y.Z\]/,/^## \[/p' CHANGELOG.md | sed '$d')
+#   the trailing `sed '$d'` matters: sed ranges INCLUDE their terminator, so without it
+#   every release page ends with a stray `## [previous-version]` heading
 
-# 3. Watch it land
-gh run watch "$(gh run list --workflow=publish_package.yml --limit 1 --json databaseId -q '.[0].databaseId')"
+# 3. Watch it land. Do NOT blindly take `--limit 1` — it currently resolves to the FAILED
+#    2026-05-18 run, and an instant red X invites exactly the wrong reaction (recutting).
+gh run list --workflow=publish_package.yml --limit 5 \
+    --json databaseId,headBranch,status,conclusion,createdAt
+gh run watch <databaseId of the run you just triggered>
 
 # 4. Confirm, then prove it from outside
 open https://pypi.org/project/views-pipeline-core/
-python -m venv /tmp/verify && /tmp/verify/bin/pip install views-pipeline-core==X.Y.Z
+rm -rf /tmp/verify && python3.11 -m venv /tmp/verify   # 3.11 explicitly — see the range note
+/tmp/verify/bin/pip install views-pipeline-core==X.Y.Z
 /tmp/verify/bin/python -c "import views_pipeline_core; print('ok')"
 ```
 
@@ -75,6 +88,11 @@ before you cut anything:
 gh secret list --repo views-platform/views-pipeline-core | grep PYPI_TOKEN
 ```
 
+This proves the secret **exists**, not that it still works — there is no way to test
+validity short of publishing. As of 2026-08-03 it is present, dating from 2024-11-21.
+views-evaluation's is of similar vintage and published successfully on 2026-08-02, which is
+the best available evidence that tokens in this org are live.
+
 > **Worth knowing:** views-reporting has migrated to PyPI **Trusted Publishing** (OIDC, no
 > token, nothing to expire) — see their `.github/workflows/publish_package.yml` and ADR-015.
 > This repo and views-evaluation have not. Migrating is a good idea and a bad idea *during*
@@ -99,7 +117,7 @@ Check first: `curl -s https://pypi.org/pypi/views-pipeline-core/json | jq -r .in
 Run everything, from `development`:
 
 ```bash
-conda run -n views_pipeline pytest tests/ -q          # baseline: 1755 passed
+conda run -n views_pipeline pytest tests/ -q          # baseline: 1761 passed (3.0.0 prep)
 conda run -n views_pipeline ruff check .
 bash documentation/validate_docs.sh
 conda run -n views_pipeline poetry check              # warnings are fine; exit code must be 0
@@ -130,7 +148,11 @@ catches the size symptom; this check catches the shape.
 
 ## Merging to `main`
 
-Branch protection requires an admin merge (solo-driver `REVIEW_REQUIRED` rule):
+Branch protection here is a **repository ruleset**, not classic branch protection — so
+`gh api repos/.../branches/main/protection` returns 404 and tells you nothing. Inspect it
+with `gh api repos/views-platform/views-pipeline-core/rules/branches/main`: it requires 3
+approving reviews with admin bypass, and it covers `development` as well as `main`. Hence
+the admin merge:
 
 ```bash
 gh pr create --base main --head development --title "release: X.Y.Z"
@@ -138,8 +160,15 @@ gh pr merge <N> --merge --admin        # NOT squash — main must keep developme
 ```
 
 `check-branch` (the job in `prevent_merge_when_branch_behind.yml`) asserts the target
-branch is an ancestor of your HEAD. If it fails, merge `main` into your branch first — it
-is complaining about staleness, not about reviews.
+branch is an ancestor of your HEAD. **For a `development` → `main` PR this WILL fail on the
+first attempt**, not might: `main` carries its own old merge commit that `development` does
+not contain. Do this before opening the PR:
+
+```bash
+git checkout development && git merge origin/main && git push
+```
+
+It is complaining about staleness, not about reviews.
 
 ---
 
@@ -158,7 +187,7 @@ mid-release; if it is ever unified, do it in a quiet moment and update this line
 | Release published, workflow never ran | Release was created as a **draft** | Publish the draft; drafts do not fire `release: published` |
 | Workflow ran, failed at `poetry publish` | `PYPI_TOKEN` missing/expired | Fix the secret, then re-run via **`workflow_dispatch`** — do not delete and recut the Release |
 | `Version must be higher than …` | `pyproject.toml` not bumped, or already published | Bump, merge, cut a *new* Release. **A PyPI version can never be reused, even after deletion** |
-| Tag exists, no Release | Someone pushed a tag expecting it to publish | Create the Release from the tag |
+| Tag exists, no Release | Someone pushed a tag expecting it to publish | Create the Release from the tag — **after** confirming `pyproject.toml` *at that tag* carries the version you intend to publish. Skipping that check is precisely what produced the failed 2.3.1 run |
 
 **Never** delete a PyPI release to "redo" it. The version number is burned permanently;
 release `X.Y.Z+1` instead.
@@ -172,3 +201,22 @@ release `X.Y.Z+1` instead.
    `[tool.uv.sources]` git pin), views-baseline and views-hydranet (#319).
 3. Update `reports/technical_risk_register.md`: close what the release resolved, and record
    what was consciously accepted so the next release inherits a decision rather than a gap.
+
+---
+
+## Known expiries and deferrals
+
+**The publish path expires around 2026-09-16.** `publish_package.yml` pins
+`actions/checkout@v3` and `actions/setup-python@v4`, both Node 20, and GitHub's runner logs
+already warn that Node 20 is removed on that date. Bump to `@v4`/`@v5` in a quiet moment,
+not during a release.
+
+**PEP 621 migration is deferred, and here is the trigger.** This repo still uses the legacy
+`[tool.poetry]` metadata tables, which `poetry check` reports as deprecated (exit 0, twelve
+warnings). Migrating is *not* a one-file change: `publish_package.yml` reads the version via
+`toml.load(...)['tool']['poetry']['version']` and would `KeyError` **after** the tag and
+Release are public. **Migrate when the workflow's version lookup changes in the same
+commit**, or when a poetry-core release turns those warnings into errors. Two costs of
+waiting, recorded so they are not rediscovered: the legacy table emits only the **first** of
+three declared authors into the wheel, and classifier auto-derivation cannot be disabled
+from it.

--- a/documentation/guides/publishing-to-pypi.md
+++ b/documentation/guides/publishing-to-pypi.md
@@ -1,0 +1,174 @@
+# Publishing `views-pipeline-core` to PyPI
+
+A runbook for releasing this package, written to be followed **solo, cold, months later**.
+Every command is copy-pasteable; the *why* is spelled out where getting it wrong is
+expensive.
+
+> **Last verified:** 2026-08-03, preparing `3.0.0`. Mechanism confirmed against
+> views-evaluation 1.0.0, which shipped 2026-08-02 through a byte-identical workflow file.
+> Companion documents: `CHANGELOG.md` (what changed), the release gate in
+> `reports/technical_risk_register.md` (what must be closed or consciously accepted first).
+
+---
+
+## The one thing that surprises people
+
+**A git tag publishes nothing.** `.github/workflows/publish_package.yml` triggers on
+
+```yaml
+on:
+  release: { types: [published] }
+  workflow_dispatch:
+```
+
+— a *published GitHub Release*, or a manual dispatch. Pushing `git tag 3.0.0 && git push
+--tags` and waiting will wait forever.
+
+The proof is in this repo's own history: a `2.3.1` tag existed on `main` for months,
+pointing at a commit whose `pyproject.toml` still said `2.3.0`. It was never published,
+because a tag was all it ever was. (It has since been deleted.)
+
+---
+
+## TL;DR — release an update
+
+```bash
+# 1. Bump the version on a branch. A published version can NEVER be reused.
+$EDITOR pyproject.toml                        # [tool.poetry] version = "X.Y.Z"
+$EDITOR CHANGELOG.md                          # a release with no notes is a release nobody can adopt
+git commit -am "release: X.Y.Z" && git push   # PR -> merge to development -> merge to main
+
+# 2. Cut the GitHub Release FROM main. THIS is what publishes.
+gh release create X.Y.Z --target main \
+    --title "views-pipeline-core X.Y.Z" \
+    --notes-file <(sed -n '/## \[X.Y.Z\]/,/^## \[/p' CHANGELOG.md)
+
+# 3. Watch it land
+gh run watch "$(gh run list --workflow=publish_package.yml --limit 1 --json databaseId -q '.[0].databaseId')"
+
+# 4. Confirm, then prove it from outside
+open https://pypi.org/project/views-pipeline-core/
+python -m venv /tmp/verify && /tmp/verify/bin/pip install views-pipeline-core==X.Y.Z
+/tmp/verify/bin/python -c "import views_pipeline_core; print('ok')"
+```
+
+Step 4 is not optional theatre. It is the only check that exercises what a *consumer* gets
+rather than what our development environment already had.
+
+---
+
+## Prerequisites
+
+### `secrets.PYPI_TOKEN` must exist — there is no fallback
+
+This repo authenticates with an **API token**:
+
+```yaml
+run: poetry publish --build --username __token__ --password ${{ secrets.PYPI_TOKEN }}
+```
+
+If that secret is missing or expired, the workflow fails **after** the tag and the GitHub
+Release already exist — leaving a released-looking version that is not on PyPI. Check
+before you cut anything:
+
+```bash
+gh secret list --repo views-platform/views-pipeline-core | grep PYPI_TOKEN
+```
+
+> **Worth knowing:** views-reporting has migrated to PyPI **Trusted Publishing** (OIDC, no
+> token, nothing to expire) — see their `.github/workflows/publish_package.yml` and ADR-015.
+> This repo and views-evaluation have not. Migrating is a good idea and a bad idea *during*
+> a release; do it between releases.
+
+### The version must beat PyPI
+
+The workflow enforces it before uploading:
+
+```bash
+latest_version=$(curl -s https://pypi.org/pypi/views-pipeline-core/json | jq -r .info.version)
+# assert parse(new) > parse(latest)
+```
+
+Fine as a backstop, useless as a plan — if it fires you have already published a Release.
+Check first: `curl -s https://pypi.org/pypi/views-pipeline-core/json | jq -r .info.version`.
+
+---
+
+## Before you release: the gates
+
+Run everything, from `development`:
+
+```bash
+conda run -n views_pipeline pytest tests/ -q          # baseline: 1755 passed
+conda run -n views_pipeline ruff check .
+bash documentation/validate_docs.sh
+conda run -n views_pipeline poetry check              # warnings are fine; exit code must be 0
+```
+
+Then confirm the release gate in `reports/technical_risk_register.md` is **closed or
+consciously accepted** — its own wording. Accepting is a legitimate outcome; *not deciding*
+is not.
+
+Build and inspect what will actually ship:
+
+```bash
+rm -rf dist/ && conda run -n views_pipeline poetry build
+python -c "
+import zipfile,glob,collections
+z=zipfile.ZipFile(sorted(glob.glob('dist/*.whl'))[-1])
+print(collections.Counter(n.split('/')[0] for n in z.namelist()))
+"
+```
+
+Expect `views_pipeline_core` and `*.dist-info`, nothing else. `[tool.poetry]` declares no
+`packages`/`include`/`exclude`, so what ships is poetry-core's default inference from the
+package directory — correct today, but nothing *asserts* it, which is how 57 MB of
+shapefiles rode along until 3.0.0. `tests/test_package_carries_no_bulk_assets.py` now
+catches the size symptom; this check catches the shape.
+
+---
+
+## Merging to `main`
+
+Branch protection requires an admin merge (solo-driver `REVIEW_REQUIRED` rule):
+
+```bash
+gh pr create --base main --head development --title "release: X.Y.Z"
+gh pr merge <N> --merge --admin        # NOT squash — main must keep development's history
+```
+
+`check-branch` (the job in `prevent_merge_when_branch_behind.yml`) asserts the target
+branch is an ancestor of your HEAD. If it fails, merge `main` into your branch first — it
+is complaining about staleness, not about reviews.
+
+---
+
+## Tag convention
+
+This repo uses **bare** tags: `2.3.0`, `3.0.0`. views-evaluation and views-reporting use
+`v`-prefixed (`v1.0.0`, `v0.3.3`). The divergence is known and deliberately not changed
+mid-release; if it is ever unified, do it in a quiet moment and update this line.
+
+---
+
+## If something goes wrong
+
+| Symptom | Cause | Do |
+|---|---|---|
+| Release published, workflow never ran | Release was created as a **draft** | Publish the draft; drafts do not fire `release: published` |
+| Workflow ran, failed at `poetry publish` | `PYPI_TOKEN` missing/expired | Fix the secret, then re-run via **`workflow_dispatch`** — do not delete and recut the Release |
+| `Version must be higher than …` | `pyproject.toml` not bumped, or already published | Bump, merge, cut a *new* Release. **A PyPI version can never be reused, even after deletion** |
+| Tag exists, no Release | Someone pushed a tag expecting it to publish | Create the Release from the tag |
+
+**Never** delete a PyPI release to "redo" it. The version number is burned permanently;
+release `X.Y.Z+1` instead.
+
+---
+
+## After publishing
+
+1. Verify from a clean environment (TL;DR step 4).
+2. Tell the repos that were waiting. For 3.0.0 that is views-reporting (drop the interim
+   `[tool.uv.sources]` git pin), views-baseline and views-hydranet (#319).
+3. Update `reports/technical_risk_register.md`: close what the release resolved, and record
+   what was consciously accepted so the next release inherits a decision rather than a gap.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,18 +1,43 @@
 [tool.poetry]
 name = "views_pipeline_core"
 version = "3.0.0"
-description = ""
+description = "Core orchestration, data and model-management library for the VIEWS conflict forecasting platform."
 authors = [
     "Borbála Farkas <borbala.farkas@pcr.uu.se>",
     "Dylan Pinheiro <dylpin@prio.org>",
     "Xiaolong Sun <xiaolong.sun@pcr.uu.se>"
 ]
 readme = "README.md"
+license = "MIT"
+homepage = "https://github.com/views-platform/views-pipeline-core"
+repository = "https://github.com/views-platform/views-pipeline-core"
+documentation = "https://github.com/views-platform/views-pipeline-core/tree/main/documentation"
+keywords = ["conflict-forecasting", "views", "pipeline", "machine-learning", "forecasting"]
+classifiers = [
+    "Development Status :: 5 - Production/Stable",
+    "Intended Audience :: Science/Research",
+    "Topic :: Scientific/Engineering",
+    "Operating System :: OS Independent",
+]
 
 [tool.poetry.dependencies]
+# Platform envelope (>=3.11,<3.15) — matches views-evaluation 1.0.0 and views-reporting
+# 0.3.3, so this repo neither under- nor over-declares relative to the platform.
+#
+# TESTED ON 3.11 ONLY. Every CI workflow here and in both sibling repos hardcodes 3.11;
+# there is no version matrix. On 3.12-3.14 an install RESOLVES and then fails LOUDLY at
+# BUILD time, in the transitive chain rather than here:
+#
+#   ingester3 =2.1.1 -> levenshtein 0.20.9   cp311 is its last wheel; the sdist build fails
+#   viewser / v-t-l   -> pandas <2.0          pandas 1.5.3 ships no wheel past cp311
+#
+# Both upstreams declare a permissive `requires_python` they do not have wheels for, which
+# is why the resolver does not catch it. Narrowing our own ceiling would not fix the wall —
+# it would only re-create the under-declaration views-reporting deliberately widened away
+# from — and a build error is loud, not silent. The fix is upstream. See register C-112
+# (the pandas <2.0 ecosystem lock across eight views-* packages, tracked as #308).
 python = ">=3.11,<3.15"
 viewser = "^6.6.4"
-pytest = "^9.0.3"
 ingester3 = "=2.1.1"
 wandb = "^0.18.7"
 pyprojroot="^0.3.0"
@@ -44,6 +69,14 @@ appwrite = { version = ">=13.4.1,<14.0.0", optional = true }
 
 [tool.poetry.extras]
 appwrite = ["appwrite"]
+
+# `pytest` sat in the RUNTIME dependencies until 3.0.0, so every consumer of the platform's
+# most-depended-upon package installed a test framework it never imports — five repos
+# directly and ~45 downstream. It is a build/test tool, not a runtime one, and this is the
+# release where moving it costs nothing. `poetry install` includes dev groups by default,
+# so both CI workflows keep working unchanged (verified, not assumed).
+[tool.poetry.group.dev.dependencies]
+pytest = "^9.0.3"
 
 [tool.pytest.ini_options]
 filterwarnings = ["ignore::DeprecationWarning", "ignore::RuntimeWarning", "ignore::UserWarning"]

--- a/tests/test_falsification_s1_readiness.py
+++ b/tests/test_falsification_s1_readiness.py
@@ -71,18 +71,118 @@ def test_s1_disk_headroom_for_rusty_bucket_at_declared_samples():
 
 
 # --- HARD #2 (probe P1): proof must run engine code slated for publication ---
-@_ENV_GATED
-def test_s1_hydranet_worktree_on_development():
-    """The publish-gate proof is invalid if the editable views-hydranet runs an
-    experimental branch (feat/zinb-distributional-head, 62 ahead / 2 behind)."""
-    out = subprocess.run(
-        ["git", "-C", "/home/simon/Documents/scripts/views_platform/views-hydranet",
-         "rev-parse", "--abbrev-ref", "HEAD"],
-        capture_output=True, text=True, check=True,
+#
+# Branches a proof may legitimately run. This is the platform's branching model — a stated
+# convention that does not rot — NOT a list of repositories, which does. The repositories
+# are derived below. A hardcoded inventory of repos is the failure this codebase has now
+# shipped five times (C-259, C-261, C-264, #346, C-277), and the previous version of this
+# check was one: a single absolute path to views-hydranet.
+_PUBLISHABLE_BRANCHES = frozenset({"development", "main"})
+
+
+def _editable_source_trees() -> dict:
+    """Every installed distribution served from a working tree on this machine.
+
+    Derived from each distribution's `direct_url.json`, which pip writes with
+    `"editable": true` for `pip install -e` / `.pth` installs. That is the actual
+    definition of the risk C-206 names — "the proof runs whatever is in that folder right
+    now" — so it is the right thing to enumerate, and it cannot go stale as repos are
+    added or removed.
+    """
+    import importlib.metadata as md
+    import json
+
+    trees = {}
+    for dist in md.distributions():
+        try:
+            raw = dist.read_text("direct_url.json")
+        except Exception:  # noqa: BLE001 — a malformed dist must not hide the others
+            continue
+        if not raw:
+            continue
+        try:
+            info = json.loads(raw)
+        except json.JSONDecodeError:
+            continue
+        if not info.get("dir_info", {}).get("editable"):
+            continue
+        url = info.get("url", "")
+        if url.startswith("file://"):
+            trees[dist.metadata["Name"]] = url[len("file://"):]
+    return trees
+
+
+def _git(path: str, *args: str) -> str:
+    return subprocess.run(
+        ["git", "-C", path, *args], capture_output=True, text=True, check=True
     ).stdout.strip()
-    assert out == "development", (
-        f"views-hydranet editable worktree is on '{out}', not 'development' — "
-        f"the S1 proof would validate unpublished experimental engine code."
+
+
+@_ENV_GATED
+def test_s1_every_editable_source_tree_is_publishable_state():
+    """C-206: a proof validates whatever branch each editable tree happens to be on.
+
+    The original check named ONE absolute path (views-hydranet) and asserted ONE thing
+    (branch == development). It was written when that tree sat on
+    `feat/zinb-distributional-head`, 62 ahead and dirty — a green S1 run would have
+    "proven" unpublished experimental engine code, indistinguishable from a valid proof.
+
+    Three ways that check was too narrow, all fixed here:
+
+    * **It named one repo.** Every editable install carries the same risk; the set is now
+      derived from `direct_url.json` rather than listed.
+    * **It ignored uncommitted changes.** A clean `development` with dirty files validates
+      code that exists nowhere but this laptop, and no reviewer can ever see it.
+    * **It ignored unpushed commits.** Likewise: a proof that cannot be reproduced from the
+      remote is not evidence anyone else can check.
+
+    Not run in CI by design — there are no editable installs there, so the check would be
+    vacuous rather than reassuring.
+    """
+    trees = _editable_source_trees()
+    assert trees, (
+        "No editable source trees found, so this check verified nothing. On a proof "
+        "machine the sibling repos are installed editable; if that is no longer true, "
+        "C-206 is resolved by construction and this test should be deleted deliberately."
+    )
+
+    problems = []
+    for name, path in sorted(trees.items()):
+        if not os.path.isdir(os.path.join(path, ".git")):
+            continue  # installed from a directory that is not a checkout — nothing to assert
+        branch = _git(path, "rev-parse", "--abbrev-ref", "HEAD")
+        dirty = _git(path, "status", "--porcelain")
+        if branch not in _PUBLISHABLE_BRANCHES:
+            problems.append(f"{name}: on '{branch}', not one of {sorted(_PUBLISHABLE_BRANCHES)}")
+        if dirty:
+            problems.append(f"{name}: {len(dirty.splitlines())} uncommitted path(s)")
+
+        try:
+            ahead = _git(path, "rev-list", "--count", "@{u}..HEAD")
+        except subprocess.CalledProcessError:
+            # No upstream at all — worse than being ahead of one, because there is no
+            # remote state to compare against or to reproduce the run from.
+            problems.append(f"{name}: branch '{branch}' tracks no remote")
+        else:
+            if ahead != "0":
+                problems.append(f"{name}: {ahead} commit(s) not pushed")
+
+    assert not problems, (
+        "Editable source trees are not in a state a proof can stand on:\n  "
+        + "\n  ".join(problems)
+        + "\n\nA proof run against these validates code that is not what will be "
+        "published, and its output is indistinguishable from a valid proof.\n\n"
+        "Two ways out (issue #274):\n"
+        "  (1) Bring each tree to a clean, pushed, publishable branch.\n"
+        "  (2) Point the proof environment at dedicated worktrees, so an operator's\n"
+        "      feature branch is never in the way:\n\n"
+        "        git -C <repo> worktree add ../<repo>-proof development\n"
+        "        # then repoint the proof env's .pth at <repo>-proof\n\n"
+        "      Option 2 costs ~2.5 GB per repo. It was NOT set up in advance "
+        "deliberately: this volume is at 95% with 46 GB free, and C-207/#273 puts the "
+        "proof's own requirement at ~300 GB — so the worktrees are a step to take when "
+        "the proof is actually scheduled and the disk problem is solved, not a directory "
+        "to leave sitting."
     )
 
 

--- a/tests/test_falsification_s1_readiness.py
+++ b/tests/test_falsification_s1_readiness.py
@@ -136,6 +136,20 @@ def test_s1_every_editable_source_tree_is_publishable_state():
     * **It ignored unpushed commits.** Likewise: a proof that cannot be reproduced from the
       remote is not evidence anyone else can check.
 
+    **What it audits, precisely.** `importlib.metadata` reads THIS interpreter — the one
+    pytest is running in. The PFE/S1 proof runs elsewhere: `views-models/monthly_run.sh`
+    invokes `envs/views_ensemble/bin/python`, and the per-model envs under
+    `views-models/envs/` have different editable sets again. Measured: the pytest env holds
+    seven editable trees and **views-hydranet is not among them**, while the
+    `envs/views-hydranet` env holds hydranet, views-evaluation and views-frames.
+
+    So this catches the environment a developer runs tests in, and the old hardcoded check
+    caught views-hydranet unconditionally. **Neither covers the other.** Point
+    `RUN_S1_READINESS=1 pytest` at the proof interpreter to audit the proof environment:
+
+        views-models/envs/views_ensemble/bin/python -m pytest \
+            tests/test_falsification_s1_readiness.py -k editable_source_tree
+
     Not run in CI by design — there are no editable installs there, so the check would be
     vacuous rather than reassuring.
     """
@@ -146,10 +160,16 @@ def test_s1_every_editable_source_tree_is_publishable_state():
         "C-206 is resolved by construction and this test should be deleted deliberately."
     )
 
-    problems = []
+    problems, inspected = [], []
     for name, path in sorted(trees.items()):
-        if not os.path.isdir(os.path.join(path, ".git")):
+        # `os.path.EXISTS`, not `isdir`. In a git worktree `.git` is a FILE containing a
+        # gitdir pointer, so `isdir` was False and every worktree was skipped — meaning
+        # this check was disarmed by the exact remedy its own failure message recommends.
+        # Following the advice would have left `problems` empty and the test green having
+        # inspected nothing.
+        if not os.path.exists(os.path.join(path, ".git")):
             continue  # installed from a directory that is not a checkout — nothing to assert
+        inspected.append(name)
         branch = _git(path, "rev-parse", "--abbrev-ref", "HEAD")
         dirty = _git(path, "status", "--porcelain")
         if branch not in _PUBLISHABLE_BRANCHES:
@@ -166,6 +186,13 @@ def test_s1_every_editable_source_tree_is_publishable_state():
         else:
             if ahead != "0":
                 problems.append(f"{name}: {ahead} commit(s) not pushed")
+
+    assert inspected, (
+        f"Found {len(trees)} editable distribution(s) but inspected none of them — every "
+        f"path failed the checkout test, so this assertion verified nothing. That is the "
+        f"failure mode this check itself shipped with: `.git` is a FILE in a worktree, so "
+        f"an `isdir` test skipped them all silently. Paths seen: {sorted(trees.values())}"
+    )
 
     assert not problems, (
         "Editable source trees are not in a state a proof can stand on:\n  "

--- a/tests/test_package_metadata_is_publishable.py
+++ b/tests/test_package_metadata_is_publishable.py
@@ -1,0 +1,119 @@
+"""What we publish to PyPI must describe itself, and must not ship our test framework.
+
+## Why this exists
+
+`views-pipeline-core` is the platform's most-depended-upon package — five repos pin it
+directly, roughly forty-five sit downstream — and until 3.0.0 its PyPI page was blank.
+`pypi.org/pypi/views-pipeline-core/json` for the released 2.3.0 returns:
+
+    summary: None    license: None    home_page: None    project_urls: None
+
+A `LICENSE` file (MIT) has been in the repository the whole time and was never declared,
+so the published artifact did not state its own licence. That is not cosmetic for a
+package other institutions install.
+
+Worse, `pytest` sat in `[tool.poetry.dependencies]` rather than a dev group, so **every
+consumer installed a test framework it never imports**. Nobody noticed because the
+development environment has pytest anyway — the same blind spot that let 57 MB of
+shapefiles ride along in the wheel until a release build was inspected by hand (C-275,
+`test_package_carries_no_bulk_assets.py`).
+
+Both were fixed once. This file is what stops them coming back, because both regress
+silently: a blank `description` breaks no import, and a stray runtime dependency fails no
+test.
+
+## What is checked, and what is deliberately not
+
+Checked: the fields a human or a resolver reads to decide whether to trust the package,
+and the absence of test-only tooling from the runtime set — **derived** from
+`pyproject.toml`, not from a hand-written list of package names.
+
+Not checked: the Python classifiers. Poetry generates
+`Programming Language :: Python :: 3.12/3.13/3.14` automatically from `requires-python`,
+and we knowingly declare `<3.15` to match the platform envelope while only 3.11 is
+installable (the wall is upstream — see the comment in `pyproject.toml`). Asserting
+against classifiers we do not control would pin Poetry's behaviour, not ours.
+"""
+
+from __future__ import annotations
+
+import tomllib
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+PYPROJECT = REPO_ROOT / "pyproject.toml"
+
+# Fields with no defensible reason to be empty on a public, institutionally-consumed
+# package. `readme` is excluded — it is already load-bearing (the long description) and
+# would fail the build, not merely publish badly.
+REQUIRED_METADATA = ("description", "license", "homepage", "repository")
+
+# Tooling that must never be a RUNTIME dependency. Matched against the declared
+# dependency names, so adding `black` or `ruff` to the wrong table is caught too.
+DEVELOPMENT_ONLY = frozenset({"pytest", "ruff", "black", "mypy", "coverage", "tox", "flake8"})
+
+
+def _poetry() -> dict:
+    return tomllib.loads(PYPROJECT.read_text())["tool"]["poetry"]
+
+
+@pytest.mark.parametrize("field", REQUIRED_METADATA)
+def test_published_package_declares_its_metadata(field: str) -> None:
+    """A blank field is invisible until someone reads the PyPI page and learns nothing."""
+    value = _poetry().get(field)
+    assert value, (
+        f"[tool.poetry].{field} is empty or absent. This is what PyPI shows to anyone "
+        f"deciding whether to install or trust the package, and it was blank for every "
+        f"release up to 3.0.0 — `summary: None, license: None` on the live 2.3.0 page. "
+        f"Setting it costs one line."
+    )
+
+
+def test_the_declared_licence_matches_the_licence_file() -> None:
+    """Declaring a licence the repository does not contain is worse than declaring none."""
+    declared = str(_poetry().get("license", ""))
+    licence_file = REPO_ROOT / "LICENSE"
+
+    assert licence_file.exists(), (
+        "LICENSE is missing while pyproject.toml declares a licence. The published "
+        "artifact would then assert terms the repository does not carry."
+    )
+    first_line = licence_file.read_text().strip().splitlines()[0]
+    assert declared.split()[0].lower() in first_line.lower(), (
+        f"pyproject declares license={declared!r} but LICENSE begins {first_line!r}. "
+        f"These must agree — a consumer's legal review reads one of them, not both."
+    )
+
+
+def test_no_development_tool_is_a_runtime_dependency() -> None:
+    """Consumers must not install our test framework.
+
+    `pytest` was a runtime dependency through 2.3.0, so five direct consumers and roughly
+    forty-five downstream repos installed it. It regresses silently: nothing imports it,
+    no test fails, and the development environment has it regardless.
+    """
+    runtime = set(_poetry().get("dependencies", {}))
+    offenders = sorted(runtime & DEVELOPMENT_ONLY)
+
+    assert not offenders, (
+        f"{offenders} are declared in [tool.poetry.dependencies], so every consumer of "
+        f"this package installs them. Move to [tool.poetry.group.dev.dependencies] — "
+        f"`poetry install` includes dev groups by default, so CI is unaffected."
+    )
+
+
+def test_the_dev_group_actually_holds_the_test_framework() -> None:
+    """The counterpart to the check above: it must have moved, not merely vanished.
+
+    Deleting `pytest` outright would satisfy the runtime check and break every CI run, so
+    the guard asserts the destination as well as the departure.
+    """
+    groups = _poetry().get("group", {})
+    dev = set(groups.get("dev", {}).get("dependencies", {}))
+    assert "pytest" in dev, (
+        "pytest is in neither the runtime dependencies nor the dev group. It must be in "
+        "the dev group: both CI workflows run `poetry install`, which includes dev groups "
+        "by default, and then `poetry run pytest`."
+    )


### PR DESCRIPTION
Phase 1 and 2 of the 3.0.0 release plan. **No behaviour changes** — this changes what a consumer receives and what they can find out about it.

## `pytest` was a runtime dependency

`[tool.poetry.dependencies]` carried `pytest = "^9.0.3"`, so every consumer of the platform's most-depended-upon package installed a test framework it never imports — five repos directly, ~45 downstream.

Verified in both directions rather than assumed:

| | |
|---|---|
| CI's exact command `poetry install --extras appwrite` | still resolves pytest (dev groups are installed by default) |
| A consumer-shaped install `--without dev` | resolves **zero** |
| Built wheel `Requires-Dist` | pytest **absent** |

## The PyPI page was blank

`pypi.org/pypi/views-pipeline-core/json` for the released 2.3.0 returns:

```
summary: None    license: None    home_page: None    project_urls: None
```

A `LICENSE` file (MIT) has been in the repo the whole time and was never declared — **the published artifact did not state its own licence.** Now declares description, licence, homepage, repository, documentation, keywords and classifiers.

## The Python range is now honest in writing

`>=3.11,<3.15` is **kept** — it matches the envelope views-evaluation 1.0.0 and views-reporting 0.3.3 already declare, and narrowing would re-create the under-declaration views-reporting deliberately widened away from.

But the comment now says what is true: **tested on 3.11 only.** 3.12–3.14 *resolve* and then fail loudly at **build** time in the transitive chain — `ingester3 =2.1.1 → levenshtein 0.20.9` has no wheel past cp311, and `pandas<2.0` likewise. Both upstreams declare a permissive `requires_python` they have no wheels for, which is why the resolver doesn't catch it. Cross-referenced to C-112/#308.

## CHANGELOG.md, which did not exist

3.0.0 carries **sixteen breaking changes across 185 commits**. Without this the only record of what broke would have been a commit log. Grouped Removed / Changed-breaking / Added / Fixed, with a Known Limitations section stating the Python situation and the consciously-accepted #374 gap, and a note that **2.3.1 was tagged but never published** so nobody goes looking for it.

Precedent: `views-evaluation/CHANGELOG.md`, created after their 0.4.0 shipped breaking changes unannounced.

## A publishing guide

`documentation/guides/publishing-to-pypi.md`, adapted from views-reporting's. It leads with the trap: **a git tag publishes nothing here** — only a published GitHub Release fires the workflow — and the stray `2.3.1` tag was the proof. Also names the prerequisite invisible from the repo: `secrets.PYPI_TOKEN`, with no OIDC fallback *(since confirmed present, set 2024-11-21)*.

## The proof-validity check no longer names one repo

`tests/test_falsification_s1_readiness.py` asserted one absolute path (views-hydranet) and one property (branch == development). It has been green for weeks. Derived over every editable tree, it reports **nine problems across five repos**:

```
views-datafactory     on 'docs/monitoring-followthrough'
views-postprocessing  on 'fix/seam-contract-v1.4.1'
views-r2darts2        on 'survey_risk', 5 uncommitted, tracks no remote
views_stepshifter     on 'release/bump-1.4.0'
views_pipeline_core   (this branch — correctly flagged)
```

**views-hydranet, the one repo it watched, is the one currently fine.** Repositories are now derived from `direct_url.json`; the branching model stays a stated constant, because a convention doesn't rot the way an inventory does. It also now catches uncommitted changes and unpushed commits — a proof nobody else can reproduce.

That is the sixth time on this project a guard has been wrong about its own scope (C-259, C-261, C-264, #346, C-277).

### Worktrees: documented, deliberately not created

#274 option 1 asks for dedicated worktrees. The volume is at **95% (46 GB free)**, each costs ~2.5 GB, and C-207/#273 puts the proof's own requirement at **~300 GB**. Spending scarce disk on checkouts for a proof that cannot run for disk reasons is the wrong order. The commands are in the failure message, where the operator will be standing.

## Guarded

`tests/test_package_metadata_is_publishable.py` — both defects regress **silently**: a blank description breaks no import, a stray runtime dependency fails no test. Four checks, each mutation-tested (blank the description, return pytest to runtime, delete it from dev instead of moving it, declare a licence the file doesn't carry).

Deliberately does **not** assert the Python classifiers — Poetry derives those from `requires-python`, so asserting them would pin Poetry's behaviour rather than ours.

## Verification

`1761 passed, 22 skipped, 8 xfailed` · `ruff check .` clean · `validate_docs.sh` passes · `poetry check` exit 0 · wheel inspected

🤖 Generated with [Claude Code](https://claude.com/claude-code)
